### PR TITLE
Fix #22, Use %p for printing addresses, resolves truncation

### DIFF
--- a/fsw/src/mm_app.c
+++ b/fsw/src/mm_app.c
@@ -471,8 +471,8 @@ bool MM_LookupSymbolCmd(const CFE_SB_Buffer_t *BufPtr)
                 MM_AppData.HkPacket.Address    = ResolvedAddr;
 
                 CFE_EVS_SendEvent(MM_SYM_LOOKUP_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Symbol Lookup Command: Name = '%s' Addr = 0x%08X", CmdPtr->SymName,
-                                  (unsigned int)ResolvedAddr);
+                                  "Symbol Lookup Command: Name = '%s' Addr = %p", CmdPtr->SymName,
+                                  (void *)ResolvedAddr);
                 Result = true;
             }
             else

--- a/fsw/src/mm_dump.c
+++ b/fsw/src/mm_dump.c
@@ -321,8 +321,8 @@ bool MM_DumpMemToFileCmd(const CFE_SB_Buffer_t *BufPtr)
                         {
                             CFE_EVS_SendEvent(
                                 MM_DMP_MEM_FILE_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                "Dump Memory To File Command: Dumped %d bytes from address 0x%08X to file '%s'",
-                                (int)MM_AppData.HkPacket.BytesProcessed, (unsigned int)SrcAddress, CmdPtr->FileName);
+                                "Dump Memory To File Command: Dumped %d bytes from address %p to file '%s'",
+                                (int)MM_AppData.HkPacket.BytesProcessed, (void *)SrcAddress, CmdPtr->FileName);
                             /*
                             ** Update last action statistics
                             */
@@ -540,9 +540,9 @@ bool MM_DumpInEventCmd(const CFE_SB_Buffer_t *BufPtr)
 
                     /*
                     ** Append tail
-                    ** This adds up to 33 characters including the NUL terminator
+                    ** This adds up to 33 characters depending on pointer representation including the NUL terminator
                     */
-                    snprintf(TempString, MM_DUMPINEVENT_TEMP_CHARS, "from address: 0x%08lX", (unsigned long)SrcAddress);
+                    snprintf(TempString, MM_DUMPINEVENT_TEMP_CHARS, "from address: %p", (void *)SrcAddress);
                     strncat(EventString, TempString, strlen(TempString));
 
                     /* Send it out */

--- a/fsw/src/mm_load.c
+++ b/fsw/src/mm_load.c
@@ -171,14 +171,14 @@ bool MM_PokeMem(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
         MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
 
         CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
-                          "Poke Command: Addr = 0x%08X, Size = %d bits, Data = 0x%08X", (unsigned int)DestAddress,
-                          DataSize, (unsigned int)DataValue);
+                          "Poke Command: Addr = %p, Size = %d bits, Data = 0x%08X", (void *)DestAddress, DataSize,
+                          (unsigned int)DataValue);
     }
     else
     {
         CFE_EVS_SendEvent(MM_PSP_WRITE_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "PSP write memory error: RC=0x%08X, Address=0x%08X, MemType=MEM%d", (unsigned int)PSP_Status,
-                          (unsigned int)DestAddress, DataSize);
+                          "PSP write memory error: RC=0x%08X, Address=%p, MemType=MEM%d", (unsigned int)PSP_Status,
+                          (void *)DestAddress, DataSize);
     }
 
     return ValidPoke;
@@ -212,14 +212,14 @@ bool MM_PokeEeprom(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
             if (PSP_Status != CFE_PSP_SUCCESS)
             {
                 CFE_EVS_SendEvent(MM_OS_EEPROMWRITE8_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "CFE_PSP_EepromWrite8 error received: RC = 0x%08X, Addr = 0x%08X",
-                                  (unsigned int)PSP_Status, (unsigned int)DestAddress);
+                                  "CFE_PSP_EepromWrite8 error received: RC = 0x%08X, Addr = %p",
+                                  (unsigned int)PSP_Status, (void *)DestAddress);
             }
             else
             {
                 CFE_EVS_SendEvent(MM_POKE_BYTE_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Poke Command: Addr = 0x%08X, Size = 8 bits, Data = 0x%02X",
-                                  (unsigned int)DestAddress, ByteValue);
+                                  "Poke Command: Addr = %p, Size = 8 bits, Data = 0x%02X", (void *)DestAddress,
+                                  ByteValue);
                 ValidPoke = true;
             }
             break;
@@ -232,14 +232,14 @@ bool MM_PokeEeprom(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
             if (PSP_Status != CFE_PSP_SUCCESS)
             {
                 CFE_EVS_SendEvent(MM_OS_EEPROMWRITE16_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "CFE_PSP_EepromWrite16 error received: RC = 0x%08X, Addr = 0x%08X",
-                                  (unsigned int)PSP_Status, (unsigned int)DestAddress);
+                                  "CFE_PSP_EepromWrite16 error received: RC = 0x%08X, Addr = %p",
+                                  (unsigned int)PSP_Status, (void *)DestAddress);
             }
             else
             {
                 CFE_EVS_SendEvent(MM_POKE_WORD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Poke Command: Addr = 0x%08X, Size = 16 bits, Data = 0x%04X",
-                                  (unsigned int)DestAddress, WordValue);
+                                  "Poke Command: Addr = %p, Size = 16 bits, Data = 0x%04X", (void *)DestAddress,
+                                  WordValue);
                 ValidPoke = true;
             }
             break;
@@ -251,14 +251,14 @@ bool MM_PokeEeprom(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
             if (PSP_Status != CFE_PSP_SUCCESS)
             {
                 CFE_EVS_SendEvent(MM_OS_EEPROMWRITE32_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "CFE_PSP_EepromWrite32 error received: RC = 0x%08X, Addr = 0x%08X",
-                                  (unsigned int)PSP_Status, (unsigned int)DestAddress);
+                                  "CFE_PSP_EepromWrite32 error received: RC = 0x%08X, Addr = %p",
+                                  (unsigned int)PSP_Status, (void *)DestAddress);
             }
             else
             {
                 CFE_EVS_SendEvent(MM_POKE_DWORD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Poke Command: Addr = 0x%08X, Size = 32 bits, Data = 0x%08X",
-                                  (unsigned int)DestAddress, (unsigned int)(CmdPtr->Data));
+                                  "Poke Command: Addr = %p, Size = 32 bits, Data = 0x%08X", (void *)DestAddress,
+                                  (unsigned int)(CmdPtr->Data));
                 ValidPoke = true;
             }
             break;
@@ -328,8 +328,8 @@ bool MM_LoadMemWIDCmd(const CFE_SB_Buffer_t *BufPtr)
 
                     CmdResult = true;
                     CFE_EVS_SendEvent(MM_LOAD_WID_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                      "Load Memory WID Command: Wrote %d bytes to address: 0x%08X",
-                                      (int)CmdPtr->NumOfBytes, (unsigned int)DestAddress);
+                                      "Load Memory WID Command: Wrote %d bytes to address: %p", (int)CmdPtr->NumOfBytes,
+                                      (void *)DestAddress);
 
                     /* Update last action statistics */
                     MM_AppData.HkPacket.LastAction     = MM_LOAD_WID;
@@ -471,9 +471,9 @@ bool MM_LoadMemFromFileCmd(const CFE_SB_Buffer_t *BufPtr)
                                     {
                                         CFE_EVS_SendEvent(MM_LD_MEM_FILE_INF_EID, CFE_EVS_EventType_INFORMATION,
                                                           "Load Memory From File Command: Loaded %d bytes to "
-                                                          "address 0x%08X from file '%s'",
-                                                          (int)MM_AppData.HkPacket.BytesProcessed,
-                                                          (unsigned int)DestAddress, CmdPtr->FileName);
+                                                          "address %p from file '%s'",
+                                                          (int)MM_AppData.HkPacket.BytesProcessed, (void *)DestAddress,
+                                                          CmdPtr->FileName);
                                     }
 
                                 } /* end MM_VerifyFileLoadParams if */
@@ -782,8 +782,8 @@ bool MM_FillMemCmd(const CFE_SB_Buffer_t *BufPtr)
                 if (MM_AppData.HkPacket.LastAction == MM_FILL)
                 {
                     CFE_EVS_SendEvent(MM_FILL_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                      "Fill Memory Command: Filled %d bytes at address: 0x%08X with pattern: 0x%08X",
-                                      (int)MM_AppData.HkPacket.BytesProcessed, (unsigned int)DestAddress,
+                                      "Fill Memory Command: Filled %d bytes at address: %p with pattern: 0x%08X",
+                                      (int)MM_AppData.HkPacket.BytesProcessed, (void *)DestAddress,
                                       (unsigned int)MM_AppData.HkPacket.DataValue);
                 }
             }

--- a/fsw/src/mm_utils.c
+++ b/fsw/src/mm_utils.c
@@ -161,7 +161,7 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, uint8 MemType, uint8 SizeInBits)
             {
                 Valid = false;
                 CFE_EVS_SendEvent(MM_ALIGN16_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Data and address not 16 bit aligned: Addr = 0x%08X Size = %d", (unsigned int)Address,
+                                  "Data and address not 16 bit aligned: Addr = %p Size = %d", (void *)Address,
                                   SizeInBytes);
             }
             break;
@@ -172,7 +172,7 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, uint8 MemType, uint8 SizeInBits)
             {
                 Valid = false;
                 CFE_EVS_SendEvent(MM_ALIGN32_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Data and address not 32 bit aligned: Addr = 0x%08X Size = %d", (unsigned int)Address,
+                                  "Data and address not 32 bit aligned: Addr = %p Size = %d", (void *)Address,
                                   SizeInBytes);
             }
             break;
@@ -196,9 +196,9 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, uint8 MemType, uint8 SizeInBits)
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = 0x%08X Size = %d "
+                                      "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d "
                                       "MemType = MEM_RAM",
-                                      (unsigned int)OS_Status, (unsigned int)Address, SizeInBytes);
+                                      (unsigned int)OS_Status, (void *)Address, SizeInBytes);
                 }
                 break;
 
@@ -209,9 +209,9 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, uint8 MemType, uint8 SizeInBits)
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = 0x%08X Size = %d "
+                                      "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d "
                                       "MemType = MEM_EEPROM",
-                                      (unsigned int)OS_Status, (unsigned int)Address, SizeInBytes);
+                                      (unsigned int)OS_Status, (void *)Address, SizeInBytes);
                 }
                 break;
 
@@ -224,8 +224,8 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, uint8 MemType, uint8 SizeInBits)
                     Valid = false;
                     CFE_EVS_SendEvent(
                         MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = 0x%08X Size = %d MemType = MEM32",
-                        (unsigned int)OS_Status, (unsigned int)Address, SizeInBytes);
+                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d MemType = MEM32",
+                        (unsigned int)OS_Status, (void *)Address, SizeInBytes);
                 }
                 /*
                 ** Peeks and Pokes must be 32 bits wide for this memory type
@@ -248,8 +248,8 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, uint8 MemType, uint8 SizeInBits)
                     Valid = false;
                     CFE_EVS_SendEvent(
                         MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = 0x%08X Size = %d MemType = MEM16",
-                        (unsigned int)OS_Status, (unsigned int)Address, SizeInBytes);
+                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d MemType = MEM16",
+                        (unsigned int)OS_Status, (void *)Address, SizeInBytes);
                 }
                 /*
                 ** Peeks and Pokes must be 16 bits wide for this memory type
@@ -272,8 +272,8 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, uint8 MemType, uint8 SizeInBits)
                     Valid = false;
                     CFE_EVS_SendEvent(
                         MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = 0x%08X Size = %d MemType = MEM8",
-                        (unsigned int)OS_Status, (unsigned int)Address, SizeInBytes);
+                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d MemType = MEM8",
+                        (unsigned int)OS_Status, (void *)Address, SizeInBytes);
                 }
                 /*
                 ** Peeks and Pokes must be 8 bits wide for this memory type
@@ -396,8 +396,8 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, uint8 MemType, uint32 SizeInBytes,
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_ALIGN32_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "Data and address not 32 bit aligned: Addr = 0x%08X Size = %d",
-                                      (unsigned int)Address, (int)SizeInBytes);
+                                      "Data and address not 32 bit aligned: Addr = %p Size = %d", (void *)Address,
+                                      (int)SizeInBytes);
                 }
                 break;
 #endif
@@ -421,8 +421,8 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, uint8 MemType, uint32 SizeInBytes,
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_ALIGN16_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "Data and address not 16 bit aligned: Addr = 0x%08X Size = %d",
-                                      (unsigned int)Address, (int)SizeInBytes);
+                                      "Data and address not 16 bit aligned: Addr = %p Size = %d", (void *)Address,
+                                      (int)SizeInBytes);
                 }
                 break;
 #endif
@@ -470,10 +470,9 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, uint8 MemType, uint32 SizeInBytes,
         if (PSP_Status != CFE_PSP_SUCCESS)
         {
             Valid = false;
-            CFE_EVS_SendEvent(
-                MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = 0x%08X Size = %d MemType = %s",
-                (unsigned int)PSP_Status, (unsigned int)Address, (int)SizeInBytes, MemTypeStr);
+            CFE_EVS_SendEvent(MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d MemType = %s",
+                              (unsigned int)PSP_Status, (void *)Address, (int)SizeInBytes, MemTypeStr);
         }
     }
 

--- a/unit-test/mm_app_tests.c
+++ b/unit-test/mm_app_tests.c
@@ -1271,8 +1271,7 @@ void MM_LookupSymbolCmd_Test_Nominal(void)
     int32             strCmpResult;
     char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Symbol Lookup Command: Name = '%%s' Addr = 0x%%08X");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Symbol Lookup Command: Name = '%%s' Addr = %%p");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);

--- a/unit-test/mm_dump_tests.c
+++ b/unit-test/mm_dump_tests.c
@@ -526,7 +526,7 @@ void MM_DumpMemToFileCmd_Test_RAM(void)
     bool              Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Dump Memory To File Command: Dumped %%d bytes from address 0x%%08X to file '%%s'");
+             "Dump Memory To File Command: Dumped %%d bytes from address %%p to file '%%s'");
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_DUMP_MEM_TO_FILE_CC;
@@ -662,7 +662,7 @@ void MM_DumpMemToFileCmd_Test_EEPROM(void)
     bool              Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Dump Memory To File Command: Dumped %%d bytes from address 0x%%08X to file '%%s'");
+             "Dump Memory To File Command: Dumped %%d bytes from address %%p to file '%%s'");
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_DUMP_MEM_TO_FILE_CC;
@@ -740,7 +740,7 @@ void MM_DumpMemToFileCmd_Test_MEM32(void)
     bool              Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Dump Memory To File Command: Dumped %%d bytes from address 0x%%08X to file '%%s'");
+             "Dump Memory To File Command: Dumped %%d bytes from address %%p to file '%%s'");
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_DUMP_MEM_TO_FILE_CC;
@@ -817,7 +817,7 @@ void MM_DumpMemToFileCmd_Test_MEM16(void)
     bool              Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Dump Memory To File Command: Dumped %%d bytes from address 0x%%08X to file '%%s'");
+             "Dump Memory To File Command: Dumped %%d bytes from address %%p to file '%%s'");
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_DUMP_MEM_TO_FILE_CC;
@@ -894,7 +894,7 @@ void MM_DumpMemToFileCmd_Test_MEM8(void)
     bool              Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Dump Memory To File Command: Dumped %%d bytes from address 0x%%08X to file '%%s'");
+             "Dump Memory To File Command: Dumped %%d bytes from address %%p to file '%%s'");
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_DUMP_MEM_TO_FILE_CC;
@@ -1041,7 +1041,7 @@ void MM_DumpMemToFileCmd_Test_CloseError(void)
     bool              Result;
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Dump Memory To File Command: Dumped %%d bytes from address 0x%%08X to file '%%s'");
+             "Dump Memory To File Command: Dumped %%d bytes from address %%p to file '%%s'");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "OS_close error received: RC = 0x%%08X File = '%%s'");

--- a/unit-test/mm_load_tests.c
+++ b/unit-test/mm_load_tests.c
@@ -219,7 +219,7 @@ void MM_PokeCmd_Test_EEPROM(void)
     bool              Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = 0x%%08X, Size = 32 bits, Data = 0x%%08X");
+             "Poke Command: Addr = %%p, Size = 32 bits, Data = 0x%%08X");
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_POKE_CC;
@@ -267,7 +267,7 @@ void MM_PokeCmd_Test_NonEEPROM(void)
     bool              Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = 0x%%08X, Size = %%d bits, Data = 0x%%08X");
+             "Poke Command: Addr = %%p, Size = %%d bits, Data = 0x%%08X");
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_POKE_CC;
@@ -446,7 +446,7 @@ void MM_PokeMem_Test_8bit(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = 0x%%08X, Size = %%d bits, Data = 0x%%08X");
+             "Poke Command: Addr = %%p, Size = %%d bits, Data = 0x%%08X");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
@@ -493,7 +493,7 @@ void MM_PokeMem_Test_8bitError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "PSP write memory error: RC=0x%%08X, Address=0x%%08X, MemType=MEM%%d");
+             "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%d");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
@@ -538,7 +538,7 @@ void MM_PokeMem_Test_16bit(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = 0x%%08X, Size = %%d bits, Data = 0x%%08X");
+             "Poke Command: Addr = %%p, Size = %%d bits, Data = 0x%%08X");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
@@ -585,7 +585,7 @@ void MM_PokeMem_Test_16bitError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "PSP write memory error: RC=0x%%08X, Address=0x%%08X, MemType=MEM%%d");
+             "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%d");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
@@ -630,7 +630,7 @@ void MM_PokeMem_Test_32bit(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = 0x%%08X, Size = %%d bits, Data = 0x%%08X");
+             "Poke Command: Addr = %%p, Size = %%d bits, Data = 0x%%08X");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
@@ -677,7 +677,7 @@ void MM_PokeMem_Test_32bitError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "PSP write memory error: RC=0x%%08X, Address=0x%%08X, MemType=MEM%%d");
+             "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%d");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
@@ -750,7 +750,7 @@ void MM_PokeEeprom_Test_8bit(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = 0x%%08X, Size = 8 bits, Data = 0x%%02X");
+             "Poke Command: Addr = %%p, Size = 8 bits, Data = 0x%%02X");
 
     CmdPacket.MemType  = MM_EEPROM;
     CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
@@ -797,7 +797,7 @@ void MM_PokeEeprom_Test_8bitError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_EepromWrite8 error received: RC = 0x%%08X, Addr = 0x%%08X");
+             "CFE_PSP_EepromWrite8 error received: RC = 0x%%08X, Addr = %%p");
 
     CmdPacket.MemType  = MM_EEPROM;
     CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
@@ -842,7 +842,7 @@ void MM_PokeEeprom_Test_16bit(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = 0x%%08X, Size = 16 bits, Data = 0x%%04X");
+             "Poke Command: Addr = %%p, Size = 16 bits, Data = 0x%%04X");
 
     CmdPacket.MemType  = MM_EEPROM;
     CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
@@ -889,7 +889,7 @@ void MM_PokeEeprom_Test_16bitError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_EepromWrite16 error received: RC = 0x%%08X, Addr = 0x%%08X");
+             "CFE_PSP_EepromWrite16 error received: RC = 0x%%08X, Addr = %%p");
 
     CmdPacket.MemType  = MM_EEPROM;
     CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
@@ -934,7 +934,7 @@ void MM_PokeEeprom_Test_32bit(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = 0x%%08X, Size = 32 bits, Data = 0x%%08X");
+             "Poke Command: Addr = %%p, Size = 32 bits, Data = 0x%%08X");
 
     CmdPacket.MemType  = MM_EEPROM;
     CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
@@ -981,7 +981,7 @@ void MM_PokeEeprom_Test_32bitError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_EepromWrite32 error received: RC = 0x%%08X, Addr = 0x%%08X");
+             "CFE_PSP_EepromWrite32 error received: RC = 0x%%08X, Addr = %%p");
 
     CmdPacket.MemType  = MM_EEPROM;
     CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
@@ -1026,7 +1026,7 @@ void MM_LoadMemWIDCmd_Test_Nominal(void)
     bool              Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Load Memory WID Command: Wrote %%d bytes to address: 0x%%08X");
+             "Load Memory WID Command: Wrote %%d bytes to address: %%p");
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_LOAD_MEM_WID_CC;
@@ -1252,7 +1252,7 @@ void MM_LoadMemFromFileCmd_Test_RAM(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Load Memory From File Command: Loaded %%d bytes to address 0x%%08X from file '%%s'");
+             "Load Memory From File Command: Loaded %%d bytes to address %%p from file '%%s'");
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_RAM;
 
@@ -1355,7 +1355,7 @@ void MM_LoadMemFromFileCmd_Test_EEPROM(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Load Memory From File Command: Loaded %%d bytes to address 0x%%08X from file '%%s'");
+             "Load Memory From File Command: Loaded %%d bytes to address %%p from file '%%s'");
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_EEPROM;
 
@@ -1411,7 +1411,7 @@ void MM_LoadMemFromFileCmd_Test_MEM32(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Load Memory From File Command: Loaded %%d bytes to address 0x%%08X from file '%%s'");
+             "Load Memory From File Command: Loaded %%d bytes to address %%p from file '%%s'");
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_MEM32;
 
@@ -1515,7 +1515,7 @@ void MM_LoadMemFromFileCmd_Test_MEM16(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Load Memory From File Command: Loaded %%d bytes to address 0x%%08X from file '%%s'");
+             "Load Memory From File Command: Loaded %%d bytes to address %%p from file '%%s'");
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_MEM16;
 
@@ -1574,7 +1574,7 @@ void MM_LoadMemFromFileCmd_Test_MEM8(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Load Memory From File Command: Loaded %%d bytes to address 0x%%08X from file '%%s'");
+             "Load Memory From File Command: Loaded %%d bytes to address %%p from file '%%s'");
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_MEM8;
 
@@ -2413,7 +2413,7 @@ void MM_FillMemCmd_Test_RAM(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Fill Memory Command: Filled %%d bytes at address: 0x%%08X with pattern: 0x%%08X");
+             "Fill Memory Command: Filled %%d bytes at address: %%p with pattern: 0x%%08X");
 
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook3, 0);
@@ -2457,7 +2457,7 @@ void MM_FillMemCmd_Test_EEPROM(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Fill Memory Command: Filled %%d bytes at address: 0x%%08X with pattern: 0x%%08X");
+             "Fill Memory Command: Filled %%d bytes at address: %%p with pattern: 0x%%08X");
 
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook3, 0);
@@ -2501,7 +2501,7 @@ void MM_FillMemCmd_Test_MEM32(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Fill Memory Command: Filled %%d bytes at address: 0x%%08X with pattern: 0x%%08X");
+             "Fill Memory Command: Filled %%d bytes at address: %%p with pattern: 0x%%08X");
 
     UT_CmdBuf.FillMemCmd.MemType    = MM_MEM32;
     UT_CmdBuf.FillMemCmd.NumOfBytes = 4;
@@ -2547,7 +2547,7 @@ void MM_FillMemCmd_Test_MEM16(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Fill Memory Command: Filled %%d bytes at address: 0x%%08X with pattern: 0x%%08X");
+             "Fill Memory Command: Filled %%d bytes at address: %%p with pattern: 0x%%08X");
 
     UT_CmdBuf.FillMemCmd.MemType    = MM_MEM16;
     UT_CmdBuf.FillMemCmd.NumOfBytes = 2;
@@ -2593,7 +2593,7 @@ void MM_FillMemCmd_Test_MEM8(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Fill Memory Command: Filled %%d bytes at address: 0x%%08X with pattern: 0x%%08X");
+             "Fill Memory Command: Filled %%d bytes at address: %%p with pattern: 0x%%08X");
 
     UT_CmdBuf.FillMemCmd.MemType    = MM_MEM8;
     UT_CmdBuf.FillMemCmd.NumOfBytes = 1;

--- a/unit-test/mm_utils_tests.c
+++ b/unit-test/mm_utils_tests.c
@@ -301,7 +301,7 @@ void MM_VerifyPeekPokeParams_Test_WordWidthAlignmentError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 16 bit aligned: Addr = 0x%%08X Size = %%d");
+             "Data and address not 16 bit aligned: Addr = %%p Size = %%d");
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -337,7 +337,7 @@ void MM_VerifyPeekPokeParams_Test_DWordWidthAlignmentError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 32 bit aligned: Addr = 0x%%08X Size = %%d");
+             "Data and address not 32 bit aligned: Addr = %%p Size = %%d");
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -457,7 +457,7 @@ void MM_VerifyPeekPokeParams_Test_RAMValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = MEM_RAM");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = MEM_RAM");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -496,7 +496,7 @@ void MM_VerifyPeekPokeParams_Test_EEPROMValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = MEM_EEPROM");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = MEM_EEPROM");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -535,7 +535,7 @@ void MM_VerifyPeekPokeParams_Test_MEM32ValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = MEM32");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = MEM32");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -574,7 +574,7 @@ void MM_VerifyPeekPokeParams_Test_MEM16ValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = MEM16");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = MEM16");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -613,7 +613,7 @@ void MM_VerifyPeekPokeParams_Test_MEM8ValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = MEM8");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = MEM8");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -797,7 +797,7 @@ void MM_VerifyLoadDumpParams_Test_LoadRAMValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -905,7 +905,7 @@ void MM_VerifyLoadDumpParams_Test_LoadEEPROMValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1013,7 +1013,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32ValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1121,7 +1121,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32AlignmentError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 32 bit aligned: Addr = 0x%%08X Size = %%d");
+             "Data and address not 32 bit aligned: Addr = %%p Size = %%d");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -1156,7 +1156,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16ValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1264,7 +1264,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16AlignmentError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 16 bit aligned: Addr = 0x%%08X Size = %%d");
+             "Data and address not 16 bit aligned: Addr = %%p Size = %%d");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -1299,7 +1299,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM8ValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1591,7 +1591,7 @@ void MM_VerifyLoadDumpParams_Test_DumpRAMRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1702,7 +1702,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROMRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1813,7 +1813,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32RangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1924,7 +1924,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32AlignmentError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 32 bit aligned: Addr = 0x%%08X Size = %%d");
+             "Data and address not 32 bit aligned: Addr = %%p Size = %%d");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1960,7 +1960,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16RangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2071,7 +2071,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16AlignmentError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 16 bit aligned: Addr = 0x%%08X Size = %%d");
+             "Data and address not 16 bit aligned: Addr = %%p Size = %%d");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -2107,7 +2107,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8RangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2450,7 +2450,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventRAMRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2489,7 +2489,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventEEPROMRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2528,7 +2528,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32RangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2567,7 +2567,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32AlignmentError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 32 bit aligned: Addr = 0x%%08X Size = %%d");
+             "Data and address not 32 bit aligned: Addr = %%p Size = %%d");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2603,7 +2603,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16RangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2642,7 +2642,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16AlignmentError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 16 bit aligned: Addr = 0x%%08X Size = %%d");
+             "Data and address not 16 bit aligned: Addr = %%p Size = %%d");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2678,7 +2678,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM8RangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2757,7 +2757,7 @@ void MM_VerifyLoadDumpParams_Test_FillRAMValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2865,7 +2865,7 @@ void MM_VerifyLoadDumpParams_Test_FillEEPROMValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2973,7 +2973,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32ValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -3081,7 +3081,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32AlignmentError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 32 bit aligned: Addr = 0x%%08X Size = %%d");
+             "Data and address not 32 bit aligned: Addr = %%p Size = %%d");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -3116,7 +3116,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16ValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -3224,7 +3224,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16AlignmentError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 16 bit aligned: Addr = 0x%%08X Size = %%d");
+             "Data and address not 16 bit aligned: Addr = %%p Size = %%d");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -3259,7 +3259,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM8ValidateRangeError(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -3423,7 +3423,7 @@ void MM_VerifyLoadDumpParams_Test_WIDMemValidateError(void)
     bool   Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = 0x%%08X Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/MM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #22

**Testing performed**
Built and ran unit tests, passed

**Expected behavior changes**
No longer truncates addresses in event messages

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit (w/ app additions)

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC