### PR TITLE
Fix #27, Remove CFE_PSP_MemSet and CFE_PSP_MemCpy use for addresses in RAM

### DIFF
--- a/fsw/src/mm_dump.c
+++ b/fsw/src/mm_dump.c
@@ -221,14 +221,14 @@ bool MM_DumpMemToFileCmd(const CFE_SB_Buffer_t *BufPtr)
                 /*
                 ** Initialize the cFE primary file header structure
                 */
-                memset(&CFEFileHeader, 0, sizeof(CFE_FS_Header_t));
+                memset(&CFEFileHeader, 0, sizeof(CFEFileHeader));
                 CFEFileHeader.SubType = MM_CFE_HDR_SUBTYPE;
                 strncpy(&CFEFileHeader.Description[0], MM_CFE_HDR_DESCRIPTION, CFE_FS_HDR_DESC_MAX_LEN);
 
                 /*
                 ** Initialize the MM secondary file header structure
                 */
-                memset(&MMFileHeader, 0, sizeof(MM_LoadDumpFileHeader_t));
+                memset(&MMFileHeader, 0, sizeof(MMFileHeader));
                 MMFileHeader.SymAddress.SymName[0] = MM_CLEAR_SYMNAME;
 
                 /*

--- a/unit-test/mm_app_tests.c
+++ b/unit-test/mm_app_tests.c
@@ -230,7 +230,7 @@ void MM_AppInit_Test_Nominal(void)
 
     /* Initialize all elements to 1, in order verify that elements initialized to 0 by MM_AppInit are actually
      * initialized */
-    CFE_PSP_MemSet(&MM_AppData, 1, sizeof(MM_AppData_t));
+    memset(&MM_AppData, 1, sizeof(MM_AppData));
 
     /* Execute the function being tested */
     Result = MM_AppInit();
@@ -267,7 +267,7 @@ void MM_AppInit_Test_EVSRegisterError(void)
 
     /* Initialize all elements to 1, in order verify that elements initialized to 0 by MM_AppInit are actually
      * initialized */
-    CFE_PSP_MemSet(&MM_AppData, 1, sizeof(MM_AppData_t));
+    memset(&MM_AppData, 1, sizeof(MM_AppData));
 
     /* Set to generate system log message "MM App: Error Registering For Event Services " */
     UT_SetDeferredRetcode(UT_KEY(CFE_EVS_Register), 1, -1);
@@ -302,7 +302,7 @@ void MM_AppInit_Test_SBCreatePipeError(void)
 
     /* Initialize all elements to 1, in order verify that elements initialized to 0 by MM_AppInit are actually
      * initialized */
-    CFE_PSP_MemSet(&MM_AppData, 1, sizeof(MM_AppData_t));
+    memset(&MM_AppData, 1, sizeof(MM_AppData));
 
     /* Set to generate system log message "MM App: Error Creating SB Pipe" */
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_CreatePipe), -1);
@@ -337,7 +337,7 @@ void MM_AppInit_Test_SBSubscribeHKError(void)
 
     /* Initialize all elements to 1, in order verify that elements initialized to 0 by MM_AppInit are actually
      * initialized */
-    CFE_PSP_MemSet(&MM_AppData, 1, sizeof(MM_AppData_t));
+    memset(&MM_AppData, 1, sizeof(MM_AppData));
 
     /* Set to generate system log message "MM App: Error Subscribing to HK Request" */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 1, -1);
@@ -372,7 +372,7 @@ void MM_AppInit_Test_SBSubscribeMMError(void)
 
     /* Initialize all elements to 1, in order verify that elements initialized to 0 by MM_AppInit are actually
      * initialized */
-    CFE_PSP_MemSet(&MM_AppData, 1, sizeof(MM_AppData_t));
+    memset(&MM_AppData, 1, sizeof(MM_AppData));
 
     /* Set to generate system log message "MM App: Error Subscribing to MM Command" */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 2, -1);

--- a/unit-test/mm_dump_tests.c
+++ b/unit-test/mm_dump_tests.c
@@ -64,7 +64,6 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook1(void *UserObj, int32 StubRetcode, ui
 {
     cpuaddr *ResolvedAddress = (cpuaddr *)Context->ArgPtr[1];
 
-    /* provide a valid address for CFE_PSP_MemCpy */
     *ResolvedAddress = (cpuaddr)DummyBuffer;
 
     return true;
@@ -552,9 +551,6 @@ void MM_DumpMemToFileCmd_Test_RAM(void)
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
 
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
-
     UT_SetDefaultReturnValue(UT_KEY(MM_ResolveSymAddr), true);
 
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyLoadDumpParams), true);
@@ -627,9 +623,6 @@ void MM_DumpMemToFileCmd_Test_BadType(void)
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
 
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
-
     UT_SetDefaultReturnValue(UT_KEY(MM_ResolveSymAddr), true);
 
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyLoadDumpParams), true);
@@ -687,9 +680,6 @@ void MM_DumpMemToFileCmd_Test_EEPROM(void)
 
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
-
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
 
     UT_SetDefaultReturnValue(UT_KEY(MM_ResolveSymAddr), true);
 
@@ -762,9 +752,6 @@ void MM_DumpMemToFileCmd_Test_MEM32(void)
 
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
-
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -840,9 +827,6 @@ void MM_DumpMemToFileCmd_Test_MEM16(void)
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
 
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
-
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
 
@@ -917,9 +901,6 @@ void MM_DumpMemToFileCmd_Test_MEM8(void)
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
 
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
-
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
 
@@ -993,9 +974,6 @@ void MM_DumpMemToFileCmd_Test_ComputeCRCError(void)
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
 
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
-
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
 
@@ -1066,9 +1044,6 @@ void MM_DumpMemToFileCmd_Test_CloseError(void)
 
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
-
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -1155,9 +1130,6 @@ void MM_DumpMemToFileCmd_Test_CreatError(void)
 
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
-
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -1330,9 +1302,6 @@ void MM_DumpMemToFileCmd_Test_SymNameError(void)
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
 
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
-
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
 
@@ -1392,9 +1361,6 @@ void MM_DumpMemToFileCmd_Test_NoVerifyDumpParams(void)
 
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
-
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
 
     UT_SetDefaultReturnValue(UT_KEY(MM_ResolveSymAddr), true);
 
@@ -1477,9 +1443,6 @@ void MM_DumpMemToFileCmd_Test_NoWriteHeaders(void)
 
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
-
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
 
     UT_SetDefaultReturnValue(UT_KEY(MM_ResolveSymAddr), true);
 
@@ -1807,9 +1770,6 @@ void MM_DumpInEventCmd_Test_Nominal(void)
     /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(MM_LoadDumpFileHeader_t));
 
-    /* Set to satisfy condition "Valid == true" before comment "Compute CRC of dumped data" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
-
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
     UT_SetDefaultReturnValue(UT_KEY(MM_ResolveSymAddr), true);
@@ -1995,9 +1955,6 @@ void MM_DumpInEventCmd_Test_FillDumpInvalid(void)
 
     /* Set to generate error message MM_PSP_READ_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead8), 1, -1);
-
-    /* Set to satisfy condition "Valid == false" after comment "Fill a local data buffer with the dump words" */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, -1);
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -2330,7 +2287,6 @@ void UtTest_Setup(void)
     UtTest_Add(MM_PeekMem_Test_DefaultSwitch, MM_Test_Setup, MM_Test_TearDown, "MM_PeekMem_Test_DefaultSwitch");
     UtTest_Add(MM_PeekMem_Test_NoLengthVerify, MM_Test_Setup, MM_Test_TearDown, "MM_PeekMem_Test_NoLengthVerify");
 
-    /* CFE_PSP_MemCpy stub and MM_SymAddr_t Offset type causes segmentation faults for these 2 tests */
     UtTest_Add(MM_DumpMemToFileCmd_Test_RAM, MM_Test_Setup, MM_Test_TearDown, "MM_DumpMemToFileCmd_Test_RAM");
     UtTest_Add(MM_DumpMemToFileCmd_Test_BadType, MM_Test_Setup, MM_Test_TearDown, "MM_DumpMemToFileCmd_Test_BadType");
     UtTest_Add(MM_DumpMemToFileCmd_Test_EEPROM, MM_Test_Setup, MM_Test_TearDown, "MM_DumpMemToFileCmd_Test_EEPROM");
@@ -2357,7 +2313,6 @@ void UtTest_Setup(void)
     UtTest_Add(MM_DumpMemToFileCmd_Test_NoWriteHeaders, MM_Test_Setup, MM_Test_TearDown,
                "MM_DumpMemToFileCmd_Test_NoWriteHeaders");
 
-    /* CFE_PSP_MemCpy stub and MM_SymAddr_t Offset type causes segmentation faults for these 3 tests */
     UtTest_Add(MM_DumpMemToFile_Test_Nominal, MM_Test_Setup, MM_Test_TearDown, "MM_DumpMemToFile_Test_Nominal");
     UtTest_Add(MM_DumpMemToFile_Test_CPUHogging, MM_Test_Setup, MM_Test_TearDown, "MM_DumpMemToFile_Test_CPUHogging");
     UtTest_Add(MM_DumpMemToFile_Test_WriteError, MM_Test_Setup, MM_Test_TearDown, "MM_DumpMemToFile_Test_WriteError");

--- a/unit-test/mm_load_tests.c
+++ b/unit-test/mm_load_tests.c
@@ -87,15 +87,11 @@ int32 UT_MM_LOAD_TEST_MM_ComputeCrcHook1(void *UserObj, int32 StubRetcode, uint3
 int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook1(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                             const UT_StubContext_t *Context)
 {
-    uint32 *SymbolAddress = (uint32 *)Context->ArgPtr[0];
-
+    uint32 * SymbolAddress   = (uint32 *)Context->ArgPtr[0];
     cpuaddr *ResolvedAddress = (cpuaddr *)Context->ArgPtr[1];
 
-    /* provide a valid address for CFE_PSP_MemCpy */
     *ResolvedAddress = (cpuaddr)DummyBuffer;
-
-    *SymbolAddress = 0;
-
+    *SymbolAddress   = 0;
     *MMHeaderRestore = MMHeaderSave;
 
     return true;
@@ -104,15 +100,11 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook1(void *UserObj, int32 StubRetcode, ui
 int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook2(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                             const UT_StubContext_t *Context)
 {
-    uint32 *SymbolAddress = (uint32 *)Context->ArgPtr[0];
-
+    uint32 * SymbolAddress   = (uint32 *)Context->ArgPtr[0];
     cpuaddr *ResolvedAddress = (cpuaddr *)Context->ArgPtr[1];
 
-    /* provide a valid address for CFE_PSP_MemCpy */
     *ResolvedAddress = (cpuaddr)DummyBuffer;
-
-    *SymbolAddress = 0;
-
+    *SymbolAddress   = 0;
     *MMHeaderRestore = MMHeaderSave;
 
     return false;
@@ -123,7 +115,6 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook3(void *UserObj, int32 StubRetcode, ui
 {
     cpuaddr *ResolvedAddress = (cpuaddr *)Context->ArgPtr[1];
 
-    /* provide a valid address for CFE_PSP_MemCpy */
     *ResolvedAddress = (cpuaddr)DummyBuffer;
 
     return true;
@@ -1046,9 +1037,6 @@ void MM_LoadMemWIDCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(MM_ResolveSymAddr), 1, true);
 
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyLoadDumpParams), true);
-
-    /* Set to prevent segmentation fault */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemCpy), 1, CFE_PSP_SUCCESS);
 
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook3, 0);

--- a/unit-test/mm_utils_tests.c
+++ b/unit-test/mm_utils_tests.c
@@ -3599,7 +3599,7 @@ void MM_ResolveSymAddr_Test(void)
     cpuaddr      ResolvedAddr = 0;
     bool         Result;
 
-    memset(&SymAddr, 0, sizeof(MM_SymAddr_t));
+    memset(&SymAddr, 0, sizeof(SymAddr));
 
     SymAddr.Offset = 99;
 

--- a/unit-test/utilities/mm_test_utils.c
+++ b/unit-test/utilities/mm_test_utils.c
@@ -80,7 +80,7 @@ void MM_Test_Setup(void)
     /* initialize test environment to default state for every test */
     UT_ResetState(0);
 
-    memset(&MM_AppData, 0, sizeof(MM_AppData_t));
+    memset(&MM_AppData, 0, sizeof(MM_AppData));
     memset(context_CFE_EVS_SendEvent, 0, sizeof(context_CFE_EVS_SendEvent));
     memset(&context_CFE_ES_WriteToSysLog, 0, sizeof(context_CFE_ES_WriteToSysLog));
     memset(&UT_CmdBuf, 0, sizeof(UT_CmdBuf));


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/MM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #27

**Testing performed**
CI

**Expected behavior changes**
None, just removes unnecessary API dependence

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC