### PR TITLE
Fix #47, Remove redundant/inconsistent comments (/* end of function */, /* end if */ etc.) and clean up empty lines.

### DIFF
--- a/fsw/src/mm_app.c
+++ b/fsw/src/mm_app.c
@@ -120,8 +120,7 @@ void MM_AppMain(void)
     ** Exit the application
     */
     CFE_ES_ExitApp(MM_AppData.RunStatus);
-
-} /* end MM_AppMain */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -219,8 +218,7 @@ int32 MM_AppInit(void)
                       MM_MAJOR_VERSION, MM_MINOR_VERSION, MM_REVISION, MM_MISSION_REV);
 
     return CFE_SUCCESS;
-
-} /* end MM_AppInit */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -337,8 +335,7 @@ void MM_AppPipe(const CFE_SB_Buffer_t *BufPtr)
             break;
 
     } /* end switch */
-
-} /* End MM_AppPipe */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -354,7 +351,6 @@ void MM_HousekeepingCmd(const CFE_SB_Buffer_t *BufPtr)
     */
     if (MM_VerifyCmdLength(&BufPtr->Msg, ExpectedLength))
     {
-
         /*
         ** Send housekeeping telemetry packet
         */
@@ -366,8 +362,7 @@ void MM_HousekeepingCmd(const CFE_SB_Buffer_t *BufPtr)
         */
 
     } /* end if */
-
-} /* end MM_HousekeepingCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -391,8 +386,7 @@ bool MM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return Result;
-
-} /* end MM_NoopCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -417,8 +411,7 @@ bool MM_ResetCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return Result;
-
-} /* end MM_ResetCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -482,8 +475,7 @@ bool MM_LookupSymbolCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end MM_VerifyCmdLength if */
 
     return Result;
-
-} /* end MM_LookupSymbolCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -543,8 +535,7 @@ bool MM_SymTblToFileCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end MM_VerifyCmdLength if */
 
     return Result;
-
-} /* end MM_SymTblToFileCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -590,8 +581,7 @@ bool MM_EepromWriteEnaCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end MM_VerifyCmdLength if */
 
     return Result;
-
-} /* end MM_EepromWriteEnaCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -636,9 +626,4 @@ bool MM_EepromWriteDisCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end MM_VerifyCmdLength if */
 
     return Result;
-
-} /* end MM_EepromWriteDisCmd */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/mm_dump.c
+++ b/fsw/src/mm_dump.c
@@ -86,8 +86,7 @@ bool MM_PeekCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end MM_VerifyCmdLength if */
 
     return Result;
-
-} /* end MM_PeekCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -178,8 +177,7 @@ bool MM_PeekMem(const MM_PeekCmd_t *CmdPtr, cpuaddr SrcAddress)
     }
 
     return ValidPeek;
-
-} /* end MM_PeekMem */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -364,8 +362,7 @@ bool MM_DumpMemToFileCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end MM_VerifyCmdLength if */
 
     return Valid;
-
-} /* end MM_DumpMemoryToFileCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -425,8 +422,7 @@ bool MM_DumpMemToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadD
     }
 
     return ValidDump;
-
-} /* end MM_DumpMemToFile */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -471,8 +467,7 @@ bool MM_WriteFileHeaders(const char *FileName, osal_id_t FileHandle, CFE_FS_Head
     } /* end CFE_FS_WriteHeader else */
 
     return Valid;
-
-} /* end MM_WriteFileHeaders */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -563,8 +558,7 @@ bool MM_DumpInEventCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end MM_VerifyCmdLength if */
 
     return Valid;
-
-} /* end MM_DumpWordsInEventCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -670,9 +664,4 @@ bool MM_FillDumpInEventBuffer(cpuaddr SrcAddress, const MM_DumpInEventCmd_t *Cmd
     } /* end CmdPtr->MemType switch */
 
     return Valid;
-
-} /* end FillDumpInEventBuffer */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/mm_load.c
+++ b/fsw/src/mm_load.c
@@ -96,8 +96,7 @@ bool MM_PokeCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end MM_VerifyCmdLength if */
 
     return Valid;
-
-} /* end MM_PokeCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -182,8 +181,7 @@ bool MM_PokeMem(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
     }
 
     return ValidPoke;
-
-} /* end MM_PokeMem */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -284,8 +282,7 @@ bool MM_PokeEeprom(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
     CFE_ES_PerfLogExit(MM_EEPROM_POKE_PERF_ID);
 
     return ValidPoke;
-
-} /* end MM_PokeEeprom */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -322,7 +319,6 @@ bool MM_LoadMemWIDCmd(const CFE_SB_Buffer_t *BufPtr)
                 */
                 if (ComputedCRC == CmdPtr->Crc)
                 {
-
                     /* Load input data to input memory address */
                     memcpy((void *)DestAddress, CmdPtr->DataArray, CmdPtr->NumOfBytes);
 
@@ -356,8 +352,7 @@ bool MM_LoadMemWIDCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end MM_VerifyCmdLength if */
 
     return CmdResult;
-
-} /* end MM_LoadMemWIDCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -551,8 +546,7 @@ bool MM_LoadMemFromFileCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end MM_VerifyCmdLength if */
 
     return Valid;
-
-} /* end LoadMemFromFileCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -622,8 +616,7 @@ bool MM_LoadMemFromFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
     }
 
     return Valid;
-
-} /* end MM_LoadMemFromFile */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -632,7 +625,6 @@ bool MM_LoadMemFromFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_VerifyLoadFileSize(const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader)
 {
-
     bool       Valid = true;
     int32      OS_Status;
     uint32     ExpectedSize;
@@ -675,8 +667,7 @@ bool MM_VerifyLoadFileSize(const char *FileName, const MM_LoadDumpFileHeader_t *
     }
 
     return Valid;
-
-} /* end MM_VerifyLoadFileSize */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -721,8 +712,7 @@ bool MM_ReadFileHeaders(const char *FileName, osal_id_t FileHandle, CFE_FS_Heade
     } /* end CFE_FS_ReadHeader else */
 
     return Valid;
-
-} /* end MM_ReadFileHeaders */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -796,8 +786,7 @@ bool MM_FillMemCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CmdResult;
-
-} /* end MM_FillMemCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -856,9 +845,4 @@ bool MM_FillMem(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
     MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
 
     return Valid;
-
-} /* End MM_FillMem */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/mm_mem16.c
+++ b/fsw/src/mm_mem16.c
@@ -124,8 +124,7 @@ bool MM_LoadMem16FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
     }
 
     return Valid;
-
-} /* end MM_LoadMem16FromFile */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -211,8 +210,7 @@ bool MM_DumpMem16ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
     }
 
     return Valid;
-
-} /* end MM_DumpMem16ToFile */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -296,11 +294,6 @@ bool MM_FillMem16(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
     }
 
     return Result;
-
-} /* End MM_FillMem16 */
+}
 
 #endif /* MM_OPT_CODE_MEM16_MEMTYPE */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/src/mm_mem32.c
+++ b/fsw/src/mm_mem32.c
@@ -124,8 +124,7 @@ bool MM_LoadMem32FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
     }
 
     return Valid;
-
-} /* end MM_LoadMem32FromFile */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -212,8 +211,7 @@ bool MM_DumpMem32ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
     }
 
     return Valid;
-
-} /* end MM_DumpMem32ToFile */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -297,11 +295,6 @@ bool MM_FillMem32(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
     }
 
     return Result;
-
-} /* End MM_FillMem32 */
+}
 
 #endif /* MM_OPT_CODE_MEM32_MEMTYPE */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/src/mm_mem8.c
+++ b/fsw/src/mm_mem8.c
@@ -124,8 +124,7 @@ bool MM_LoadMem8FromFile(osal_id_t FileHandle, const char *FileName, const MM_Lo
     }
 
     return Valid;
-
-} /* end MM_LoadMem8FromFile */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -211,8 +210,7 @@ bool MM_DumpMem8ToFile(osal_id_t FileHandle, const char *FileName, const MM_Load
     }
 
     return Valid;
-
-} /* end MM_DumpMem8ToFile */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -285,11 +283,6 @@ bool MM_FillMem8(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
     }
 
     return Result;
-
-} /* End MM_FillMem8 */
+}
 
 #endif /* MM_OPT_CODE_MEM8_MEMTYPE */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/src/mm_utils.c
+++ b/fsw/src/mm_utils.c
@@ -51,15 +51,13 @@ extern MM_AppData_t MM_AppData;
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void MM_ResetHk(void)
 {
-
     MM_AppData.HkPacket.LastAction     = MM_NOACTION;
     MM_AppData.HkPacket.MemType        = MM_NOMEMTYPE;
     MM_AppData.HkPacket.Address        = MM_CLEAR_ADDR;
     MM_AppData.HkPacket.DataValue      = MM_CLEAR_PATTERN;
     MM_AppData.HkPacket.BytesProcessed = 0;
     MM_AppData.HkPacket.FileName[0]    = MM_CLEAR_FNAME;
-
-} /* end MM_ResetHk */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -82,8 +80,7 @@ void MM_SegmentBreak(void)
     ** Performance Log exit stamp
     */
     CFE_ES_PerfLogExit(MM_SEGBREAK_PERF_ID);
-
-} /* End of MM_SegmentBreak */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -104,7 +101,6 @@ bool MM_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
     CFE_MSG_GetSize(MsgPtr, &ActualLength);
     if (ExpectedLength != ActualLength)
     {
-
         CFE_MSG_GetMsgId(MsgPtr, &MessageID);
         CFE_MSG_GetFcnCode(MsgPtr, &CommandCode);
 
@@ -131,8 +127,7 @@ bool MM_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
     }
 
     return result;
-
-} /* End of MM_VerifyCmdLength */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -294,8 +289,7 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, uint8 MemType, uint8 SizeInBits)
     } /* end Valid == true if */
 
     return Valid;
-
-} /* end MM_VerifyPeekPokeParams */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -473,8 +467,7 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, uint8 MemType, uint32 SizeInBytes,
     }
 
     return Valid;
-
-} /* end MM_VerifyFileLoadDumpParams */
+}
 
 /******************************************************************************/
 
@@ -591,9 +584,4 @@ int32 MM_ComputeCRCFromFile(osal_id_t FileHandle, uint32 *CrcPtr, uint32 TypeCRC
     }
 
     return OS_Status;
-
-} /* End MM_ComputeCRCFromFile */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/mm_app_tests.c
+++ b/unit-test/mm_app_tests.c
@@ -107,8 +107,7 @@ void MM_AppMain_Test_Nominal(void)
 
     uint8 call_count_CFE_ES_ExitApp = UT_GetStubCount(UT_KEY(CFE_ES_ExitApp));
     UtAssert_INT32_EQ(call_count_CFE_ES_ExitApp, 1);
-
-} /* end MM_AppMain_Test_Nominal */
+}
 
 void MM_AppMain_Test_AppInitError(void)
 {
@@ -141,8 +140,7 @@ void MM_AppMain_Test_AppInitError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppMain_Test_AppInitError */
+}
 
 void MM_AppMain_Test_SBError(void)
 {
@@ -186,8 +184,7 @@ void MM_AppMain_Test_SBError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppMain_Test_SBError */
+}
 
 void MM_AppMain_Test_SBTimeout(void)
 {
@@ -216,8 +213,7 @@ void MM_AppMain_Test_SBTimeout(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppMain_Test_SBError */
+}
 
 void MM_AppInit_Test_Nominal(void)
 {
@@ -252,8 +248,7 @@ void MM_AppInit_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppInit_Test_Nominal */
+}
 
 void MM_AppInit_Test_EVSRegisterError(void)
 {
@@ -288,8 +283,7 @@ void MM_AppInit_Test_EVSRegisterError(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppInit_Test_EVSRegisterError */
+}
 
 void MM_AppInit_Test_SBCreatePipeError(void)
 {
@@ -323,8 +317,7 @@ void MM_AppInit_Test_SBCreatePipeError(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppInit_Test_SBCreatePipeError */
+}
 
 void MM_AppInit_Test_SBSubscribeHKError(void)
 {
@@ -358,8 +351,7 @@ void MM_AppInit_Test_SBSubscribeHKError(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppInit_Test_SBSubscribeHKError */
+}
 
 void MM_AppInit_Test_SBSubscribeMMError(void)
 {
@@ -393,8 +385,7 @@ void MM_AppInit_Test_SBSubscribeMMError(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppInit_Test_SBSubscribeMMError */
+}
 
 void MM_AppPipe_Test_SendHK(void)
 {
@@ -415,7 +406,7 @@ void MM_AppPipe_Test_SendHK(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end MM_AppPipe_Test_SendHK */
+}
 
 void MM_AppPipe_Test_NoopSuccess(void)
 {
@@ -454,7 +445,7 @@ void MM_AppPipe_Test_NoopSuccess(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end MM_AppPipe_Test_NoopSuccess */
+}
 
 void MM_AppPipe_Test_NoopFail(void)
 {
@@ -482,8 +473,7 @@ void MM_AppPipe_Test_NoopFail(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_NoopFail */
+}
 
 void MM_AppPipe_Test_ResetSuccess(void)
 {
@@ -522,7 +512,7 @@ void MM_AppPipe_Test_ResetSuccess(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end MM_AppPipe_Test_ResetSuccess */
+}
 
 void MM_AppPipe_Test_ResetFail(void)
 {
@@ -549,7 +539,7 @@ void MM_AppPipe_Test_ResetFail(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end MM_AppPipe_Test_ResetFail */
+}
 
 void MM_AppPipe_Test_PeekSuccess(void)
 {
@@ -571,8 +561,7 @@ void MM_AppPipe_Test_PeekSuccess(void)
 
     call_count_MM_PeekCmd = UT_GetStubCount(UT_KEY(MM_PeekCmd));
     UtAssert_INT32_EQ(call_count_MM_PeekCmd, 1);
-
-} /* end MM_AppPipe_Test_PeekSuccess */
+}
 
 void MM_AppPipe_Test_PeekFail(void)
 {
@@ -594,8 +583,7 @@ void MM_AppPipe_Test_PeekFail(void)
 
     call_count_MM_PeekCmd = UT_GetStubCount(UT_KEY(MM_PeekCmd));
     UtAssert_INT32_EQ(call_count_MM_PeekCmd, 1);
-
-} /* end MM_AppPipe_Test_PeekFail */
+}
 
 void MM_AppPipe_Test_PokeSuccess(void)
 {
@@ -617,8 +605,7 @@ void MM_AppPipe_Test_PokeSuccess(void)
     uint8 call_count_MM_PokeCmd = 0;
     call_count_MM_PokeCmd       = UT_GetStubCount(UT_KEY(MM_PokeCmd));
     UtAssert_INT32_EQ(call_count_MM_PokeCmd, 1);
-
-} /* end MM_AppPipe_Test_PokeSuccess */
+}
 
 void MM_AppPipe_Test_PokeFail(void)
 {
@@ -640,8 +627,7 @@ void MM_AppPipe_Test_PokeFail(void)
     uint8 call_count_MM_PokeCmd = 0;
     call_count_MM_PokeCmd       = UT_GetStubCount(UT_KEY(MM_PokeCmd));
     UtAssert_INT32_EQ(call_count_MM_PokeCmd, 1);
-
-} /* end MM_AppPipe_Test_PokeFail */
+}
 
 void MM_AppPipe_Test_LoadMemWIDSuccess(void)
 {
@@ -663,8 +649,7 @@ void MM_AppPipe_Test_LoadMemWIDSuccess(void)
     uint8 call_count_MM_LoadMemWID = 0;
     call_count_MM_LoadMemWID       = UT_GetStubCount(UT_KEY(MM_LoadMemWIDCmd));
     UtAssert_INT32_EQ(call_count_MM_LoadMemWID, 1);
-
-} /* end MM_AppPipe_Test_LoadMemWIDSuccess */
+}
 
 void MM_AppPipe_Test_LoadMemWIDFail(void)
 {
@@ -686,8 +671,7 @@ void MM_AppPipe_Test_LoadMemWIDFail(void)
     uint8 call_count_MM_LoadMemWID = 0;
     call_count_MM_LoadMemWID       = UT_GetStubCount(UT_KEY(MM_LoadMemWIDCmd));
     UtAssert_INT32_EQ(call_count_MM_LoadMemWID, 1);
-
-} /* end MM_AppPipe_Test_LoadMemWIDFail */
+}
 
 void MM_AppPipe_Test_LoadMemFromFileSuccess(void)
 {
@@ -709,8 +693,7 @@ void MM_AppPipe_Test_LoadMemFromFileSuccess(void)
     uint8 call_count_MM_LoadMemFromFile = 0;
     call_count_MM_LoadMemFromFile       = UT_GetStubCount(UT_KEY(MM_LoadMemFromFileCmd));
     UtAssert_INT32_EQ(call_count_MM_LoadMemFromFile, 1);
-
-} /* end MM_AppPipe_Test_LoadMemFromFileSuccess */
+}
 
 void MM_AppPipe_Test_LoadMemFromFileFail(void)
 {
@@ -732,8 +715,7 @@ void MM_AppPipe_Test_LoadMemFromFileFail(void)
     uint8 call_count_MM_LoadMemFromFile = 0;
     call_count_MM_LoadMemFromFile       = UT_GetStubCount(UT_KEY(MM_LoadMemFromFileCmd));
     UtAssert_INT32_EQ(call_count_MM_LoadMemFromFile, 1);
-
-} /* end MM_AppPipe_Test_LoadMemFromFileFail */
+}
 
 void MM_AppPipe_Test_DumpMemToFileSuccess(void)
 {
@@ -755,8 +737,7 @@ void MM_AppPipe_Test_DumpMemToFileSuccess(void)
     uint8 call_count_MM_DumpMemToFile = 0;
     call_count_MM_DumpMemToFile       = UT_GetStubCount(UT_KEY(MM_DumpMemToFileCmd));
     UtAssert_INT32_EQ(call_count_MM_DumpMemToFile, 1);
-
-} /* end MM_AppPipe_Test_DumpMemToFileSuccess */
+}
 
 void MM_AppPipe_Test_DumpMemToFileFail(void)
 {
@@ -778,8 +759,7 @@ void MM_AppPipe_Test_DumpMemToFileFail(void)
     uint8 call_count_MM_DumpMemToFile = 0;
     call_count_MM_DumpMemToFile       = UT_GetStubCount(UT_KEY(MM_DumpMemToFileCmd));
     UtAssert_INT32_EQ(call_count_MM_DumpMemToFile, 1);
-
-} /* end MM_AppPipe_Test_DumpMemToFileFail */
+}
 
 void MM_AppPipe_Test_DumpInEventSuccess(void)
 {
@@ -801,8 +781,7 @@ void MM_AppPipe_Test_DumpInEventSuccess(void)
     uint8 call_count_MM_DumpInEvent = 0;
     call_count_MM_DumpInEvent       = UT_GetStubCount(UT_KEY(MM_DumpInEventCmd));
     UtAssert_INT32_EQ(call_count_MM_DumpInEvent, 1);
-
-} /* end MM_AppPipe_Test_DumpInEventSuccess */
+}
 
 void MM_AppPipe_Test_DumpInEventFail(void)
 {
@@ -824,8 +803,7 @@ void MM_AppPipe_Test_DumpInEventFail(void)
     uint8 call_count_MM_DumpInEvent = 0;
     call_count_MM_DumpInEvent       = UT_GetStubCount(UT_KEY(MM_DumpInEventCmd));
     UtAssert_INT32_EQ(call_count_MM_DumpInEvent, 1);
-
-} /* end MM_AppPipe_Test_DumpInEventFail */
+}
 
 void MM_AppPipe_Test_FillMemSuccess(void)
 {
@@ -847,8 +825,7 @@ void MM_AppPipe_Test_FillMemSuccess(void)
     uint8 call_count_MM_FillMem = 0;
     call_count_MM_FillMem       = UT_GetStubCount(UT_KEY(MM_FillMemCmd));
     UtAssert_INT32_EQ(call_count_MM_FillMem, 1);
-
-} /* end MM_AppPipe_Test_FillMemSuccess */
+}
 
 void MM_AppPipe_Test_FillMemFail(void)
 {
@@ -870,12 +847,10 @@ void MM_AppPipe_Test_FillMemFail(void)
     uint8 call_count_MM_FillMem = 0;
     call_count_MM_FillMem       = UT_GetStubCount(UT_KEY(MM_FillMemCmd));
     UtAssert_INT32_EQ(call_count_MM_FillMem, 1);
-
-} /* end MM_AppPipe_Test_FillMemFail */
+}
 
 void MM_AppPipe_Test_LookupSymbolSuccess(void)
 {
-
     CFE_SB_MsgId_t    TestMsgId    = CFE_SB_ValueToMsgId(MM_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode      = MM_LOOKUP_SYM_CC;
     size_t            MsgSize      = sizeof(UT_CmdBuf.LookupSymCmd);
@@ -903,8 +878,7 @@ void MM_AppPipe_Test_LookupSymbolSuccess(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_LookupSymbolSuccess */
+}
 
 void MM_AppPipe_Test_LookupSymbolFail(void)
 {
@@ -929,12 +903,10 @@ void MM_AppPipe_Test_LookupSymbolFail(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_LookupSymbolFail */
+}
 
 void MM_AppPipe_Test_SymTblToFileSuccess(void)
 {
-
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = MM_SYMTBL_TO_FILE_CC;
     size_t            MsgSize   = sizeof(UT_CmdBuf.SymTblToFileCmd);
@@ -963,8 +935,7 @@ void MM_AppPipe_Test_SymTblToFileSuccess(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_SymTblToFileSuccess */
+}
 
 void MM_AppPipe_Test_SymTblToFileFail(void)
 {
@@ -991,8 +962,7 @@ void MM_AppPipe_Test_SymTblToFileFail(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_SymTblToFileFail */
+}
 
 void MM_AppPipe_Test_EnableEepromWriteSuccess(void)
 {
@@ -1019,8 +989,7 @@ void MM_AppPipe_Test_EnableEepromWriteSuccess(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_EnableEepromWriteSuccess */
+}
 
 void MM_AppPipe_Test_EnableEepromWriteFail(void)
 {
@@ -1045,8 +1014,7 @@ void MM_AppPipe_Test_EnableEepromWriteFail(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_EnableEepromWriteFail */
+}
 
 void MM_AppPipe_Test_DisableEepromWriteSuccess(void)
 {
@@ -1074,8 +1042,7 @@ void MM_AppPipe_Test_DisableEepromWriteSuccess(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_DisableEepromWriteSuccess */
+}
 
 void MM_AppPipe_Test_DisableEepromWriteFail(void)
 {
@@ -1101,8 +1068,7 @@ void MM_AppPipe_Test_DisableEepromWriteFail(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_DisableEepromWriteFail */
+}
 
 void MM_AppPipe_Test_InvalidCommandCode(void)
 {
@@ -1141,8 +1107,7 @@ void MM_AppPipe_Test_InvalidCommandCode(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_InvalidCommandCode */
+}
 
 void MM_AppPipe_Test_InvalidCommandPipeMessageID(void)
 {
@@ -1179,8 +1144,7 @@ void MM_AppPipe_Test_InvalidCommandPipeMessageID(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_AppPipe_Test_InvalidCommandPipeMessageID */
+}
 
 void MM_HousekeepingCmd_Test(void)
 {
@@ -1224,8 +1188,7 @@ void MM_HousekeepingCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_HousekeepingCmd_Test */
+}
 
 void MM_HousekeepingCmd_Test_NoLengthVerify(void)
 {
@@ -1241,8 +1204,7 @@ void MM_HousekeepingCmd_Test_NoLengthVerify(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_HousekeepingCmd_Test_NoLengthVerify */
+}
 
 void MM_ResetCmd_Test_NoLengthVerify(void)
 {
@@ -1258,8 +1220,7 @@ void MM_ResetCmd_Test_NoLengthVerify(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_ReseCmd_Test_NoLengthVerify */
+}
 
 void MM_LookupSymbolCmd_Test_Nominal(void)
 {
@@ -1303,8 +1264,7 @@ void MM_LookupSymbolCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_LookupSymbolCmd_Test_Nominal */
+}
 
 void MM_LookupSymbolCmd_Test_SymbolNameNull(void)
 {
@@ -1343,8 +1303,7 @@ void MM_LookupSymbolCmd_Test_SymbolNameNull(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_LookupSymbolCmd_Test_SymbolNameNull */
+}
 
 void MM_LookupSymbolCmd_Test_SymbolLookupError(void)
 {
@@ -1387,8 +1346,7 @@ void MM_LookupSymbolCmd_Test_SymbolLookupError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_LookupSymbolCmd_Test_SymbolLookupError */
+}
 
 void MM_LookupSymbolCmd_Test_NoLengthVerify(void)
 {
@@ -1404,8 +1362,7 @@ void MM_LookupSymbolCmd_Test_NoLengthVerify(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_LookupSymbolCmd_Test_NoLengthVerify */
+}
 
 void MM_SymTblToFileCmd_Test_Nominal(void)
 {
@@ -1451,8 +1408,7 @@ void MM_SymTblToFileCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_SymTblToFileCmd_Test_Nominal */
+}
 
 void MM_SymTblToFileCmd_Test_SymbolFilenameNull(void)
 {
@@ -1492,8 +1448,7 @@ void MM_SymTblToFileCmd_Test_SymbolFilenameNull(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_SymTblToFileCmd_Test_SymbolFilenameNull */
+}
 
 void MM_SymTblToFileCmd_Test_SymbolTableDumpError(void)
 {
@@ -1536,8 +1491,7 @@ void MM_SymTblToFileCmd_Test_SymbolTableDumpError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_SymTblToFileCmd_Test_SymbolTableDumpError */
+}
 
 void MM_SymTblToFileCmd_Test_NoLengthVerify(void)
 {
@@ -1553,8 +1507,7 @@ void MM_SymTblToFileCmd_Test_NoLengthVerify(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_SymTblToFileCmd_Test_NoLengthVerify */
+}
 
 void MM_EepromWriteEnaCmd_Test_Nominal(void)
 {
@@ -1599,8 +1552,7 @@ void MM_EepromWriteEnaCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_EepromWriteEnaCmd_Test_Nominal */
+}
 
 void MM_EepromWriteEnaCmd_Test_Error(void)
 {
@@ -1644,8 +1596,7 @@ void MM_EepromWriteEnaCmd_Test_Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_EepromWriteEnaCmd_Test_Error */
+}
 
 void MM_EepromWriteEnaCmd_Test_NoLengthVerify(void)
 {
@@ -1661,8 +1612,7 @@ void MM_EepromWriteEnaCmd_Test_NoLengthVerify(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_EepromWriteEnaCmd_Test_NoLengthVerify */
+}
 
 void MM_EepromWriteDisCmd_Test_Nominal(void)
 {
@@ -1707,8 +1657,7 @@ void MM_EepromWriteDisCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_EepromWriteDisCmd_Test_Nominal */
+}
 
 void MM_EepromWriteDisCmd_Test_Error(void)
 {
@@ -1752,8 +1701,7 @@ void MM_EepromWriteDisCmd_Test_Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_EepromWriteDisCmd_Test_Error */
+}
 
 void MM_EepromWriteDisCmd_Test_NoLengthVerify(void)
 {
@@ -1769,8 +1717,7 @@ void MM_EepromWriteDisCmd_Test_NoLengthVerify(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_EepromWriteDisCmd_Test_NoLengthVerify */
+}
 
 /*
  * Register the test cases to execute with the unit test tool
@@ -1859,9 +1806,4 @@ void UtTest_Setup(void)
     UtTest_Add(MM_EepromWriteDisCmd_Test_Error, MM_Test_Setup, MM_Test_TearDown, "MM_EepromWriteDisCmd_Test_Error");
     UtTest_Add(MM_EepromWriteDisCmd_Test_NoLengthVerify, MM_Test_Setup, MM_Test_TearDown,
                "MM_EepromWriteDisCmd_Test_NoLengthVerify");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/mm_dump_tests.c
+++ b/unit-test/mm_dump_tests.c
@@ -67,7 +67,7 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook1(void *UserObj, int32 StubRetcode, ui
     *ResolvedAddress = (cpuaddr)DummyBuffer;
 
     return true;
-} /* end UT_MM_LOAD_TEST_CFE_SymbolLookupHook1 */
+}
 
 int32 UT_MM_LOAD_TEST_OS_WriteHook1(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
 {
@@ -78,7 +78,7 @@ int32 UT_MM_LOAD_TEST_OS_WriteHook1(void *UserObj, int32 StubRetcode, uint32 Cal
     *ResolvedAddress = (cpuaddr)DummyBuffer;
 
     return sizeof(MM_LoadDumpFileHeader_t);
-} /* end UT_MM_LOAD_TEST_OS_WriteHook1 */
+}
 
 void MM_PeekCmd_Test_Nominal(void)
 {
@@ -126,8 +126,7 @@ void MM_PeekCmd_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PeekCmd_Test_Nominal */
+}
 
 void MM_PeekCmd_Test_SymNameError(void)
 {
@@ -178,8 +177,7 @@ void MM_PeekCmd_Test_SymNameError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_PeekCmd_Test_SymNameError */
+}
 
 void MM_PeekCmd_Test_NoVerifyPeekPokeParams(void)
 {
@@ -215,8 +213,7 @@ void MM_PeekCmd_Test_NoVerifyPeekPokeParams(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_PeekCmd_Test_NoVerifyPeekPokeParams */
+}
 
 void MM_PeekMem_Test_Byte(void)
 {
@@ -259,8 +256,7 @@ void MM_PeekMem_Test_Byte(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_PeekMem_Test_Byte */
+}
 
 void MM_PeekMem_Test_ByteError(void)
 {
@@ -298,8 +294,7 @@ void MM_PeekMem_Test_ByteError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_PeekMem_Test_ByteError */
+}
 
 void MM_PeekMem_Test_Word(void)
 {
@@ -342,8 +337,7 @@ void MM_PeekMem_Test_Word(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_PeekMem_Test_Word */
+}
 
 void MM_PeekMem_Test_WordError(void)
 {
@@ -382,8 +376,7 @@ void MM_PeekMem_Test_WordError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_PeekMem_Test_WordError */
+}
 
 void MM_PeekMem_Test_DWord(void)
 {
@@ -426,8 +419,7 @@ void MM_PeekMem_Test_DWord(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MM_PeekMem_Test_DWord */
+}
 
 void MM_PeekMem_Test_DWordError(void)
 {
@@ -466,8 +458,7 @@ void MM_PeekMem_Test_DWordError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PeekMem_Test_DWordError */
+}
 
 void MM_PeekMem_Test_DefaultSwitch(void)
 {
@@ -491,8 +482,7 @@ void MM_PeekMem_Test_DefaultSwitch(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PeekMem_Test_DefaultSwitch */
+}
 
 void MM_PeekMem_Test_NoLengthVerify(void)
 {
@@ -513,8 +503,7 @@ void MM_PeekMem_Test_NoLengthVerify(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PeekMem_Test_NoLengthVerify */
+}
 
 void MM_DumpMemToFileCmd_Test_RAM(void)
 {
@@ -590,8 +579,7 @@ void MM_DumpMemToFileCmd_Test_RAM(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_RAM */
+}
 
 void MM_DumpMemToFileCmd_Test_BadType(void)
 {
@@ -643,8 +631,7 @@ void MM_DumpMemToFileCmd_Test_BadType(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_BadType */
+}
 
 void MM_DumpMemToFileCmd_Test_EEPROM(void)
 {
@@ -718,8 +705,7 @@ void MM_DumpMemToFileCmd_Test_EEPROM(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_EEPROM */
+}
 
 void MM_DumpMemToFileCmd_Test_MEM32(void)
 {
@@ -792,8 +778,7 @@ void MM_DumpMemToFileCmd_Test_MEM32(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_MEM32 */
+}
 
 void MM_DumpMemToFileCmd_Test_MEM16(void)
 {
@@ -866,8 +851,7 @@ void MM_DumpMemToFileCmd_Test_MEM16(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_MEM16 */
+}
 
 void MM_DumpMemToFileCmd_Test_MEM8(void)
 {
@@ -939,8 +923,7 @@ void MM_DumpMemToFileCmd_Test_MEM8(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_MEM8 */
+}
 
 void MM_DumpMemToFileCmd_Test_ComputeCRCError(void)
 {
@@ -1007,8 +990,7 @@ void MM_DumpMemToFileCmd_Test_ComputeCRCError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_ComputeCRCError */
+}
 
 void MM_DumpMemToFileCmd_Test_CloseError(void)
 {
@@ -1096,8 +1078,7 @@ void MM_DumpMemToFileCmd_Test_CloseError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_CloseError */
+}
 
 void MM_DumpMemToFileCmd_Test_CreatError(void)
 {
@@ -1163,8 +1144,7 @@ void MM_DumpMemToFileCmd_Test_CreatError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_CreatError */
+}
 
 void MM_DumpMemToFileCmd_Test_InvalidDumpResult(void)
 {
@@ -1215,8 +1195,7 @@ void MM_DumpMemToFileCmd_Test_InvalidDumpResult(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_CreatError */
+}
 
 void MM_DumpMemToFileCmd_Test_lseekError(void)
 {
@@ -1267,8 +1246,7 @@ void MM_DumpMemToFileCmd_Test_lseekError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_CreatError */
+}
 
 void MM_DumpMemToFileCmd_Test_SymNameError(void)
 {
@@ -1329,8 +1307,7 @@ void MM_DumpMemToFileCmd_Test_SymNameError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_SymNameError */
+}
 
 void MM_DumpMemToFileCmd_Test_NoVerifyDumpParams(void)
 {
@@ -1386,8 +1363,7 @@ void MM_DumpMemToFileCmd_Test_NoVerifyDumpParams(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_NoVerifyDumpParams */
+}
 
 void MM_DumpMemToFileCmd_Test_NoLengthVerify(void)
 {
@@ -1409,8 +1385,7 @@ void MM_DumpMemToFileCmd_Test_NoLengthVerify(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_NoLengthVerify */
+}
 
 void MM_DumpMemToFileCmd_Test_NoWriteHeaders(void)
 {
@@ -1474,8 +1449,7 @@ void MM_DumpMemToFileCmd_Test_NoWriteHeaders(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFileCmd_Test_NoWriteHeaders */
+}
 
 void MM_DumpMemToFile_Test_Nominal(void)
 {
@@ -1515,8 +1489,7 @@ void MM_DumpMemToFile_Test_Nominal(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFile_Test_Nominal */
+}
 
 void MM_DumpMemToFile_Test_CPUHogging(void)
 {
@@ -1558,8 +1531,7 @@ void MM_DumpMemToFile_Test_CPUHogging(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFile_Test_CPUHogging */
+}
 
 void MM_DumpMemToFile_Test_WriteError(void)
 {
@@ -1605,8 +1577,7 @@ void MM_DumpMemToFile_Test_WriteError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMemToFile_Test_WriteError */
+}
 
 void MM_WriteFileHeaders_Test_Nominal(void)
 {
@@ -1639,8 +1610,7 @@ void MM_WriteFileHeaders_Test_Nominal(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_WriteFileHeaders_Test_Nominal */
+}
 
 void MM_WriteFileHeaders_Test_WriteHeaderError(void)
 {
@@ -1686,8 +1656,7 @@ void MM_WriteFileHeaders_Test_WriteHeaderError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_WriteFileHeaders_Test_WriteHeaderError */
+}
 
 void MM_WriteFileHeaders_Test_WriteError(void)
 {
@@ -1733,8 +1702,7 @@ void MM_WriteFileHeaders_Test_WriteError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_WriteFileHeaders_Test_WriteError */
+}
 
 void MM_DumpInEventCmd_Test_Nominal(void)
 {
@@ -1804,8 +1772,7 @@ void MM_DumpInEventCmd_Test_Nominal(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpInEventCmd_Test_Nominal */
+}
 
 void MM_DumpInEventCmd_Test_SymNameError(void)
 {
@@ -1859,8 +1826,7 @@ void MM_DumpInEventCmd_Test_SymNameError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpInEventCmd_Test_SymNameError */
+}
 
 void MM_DumpInEventCmd_Test_NoLengthVerify(void)
 {
@@ -1923,8 +1889,7 @@ void MM_DumpInEventCmd_Test_NoVerifyDumpParams(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpInEventCmd_Test_NoVerifyDumpParams */
+}
 
 void MM_DumpInEventCmd_Test_FillDumpInvalid(void)
 {
@@ -1973,8 +1938,7 @@ void MM_DumpInEventCmd_Test_FillDumpInvalid(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpInEventCmd_Test_FillDumpInvalid */
+}
 
 void MM_FillDumpInEventBuffer_Test_RAM(void)
 {
@@ -2001,8 +1965,7 @@ void MM_FillDumpInEventBuffer_Test_RAM(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillDumpInEventBuffer_Test_RAM */
+}
 
 void MM_FillDumpInEventBuffer_Test_BadType(void)
 {
@@ -2029,8 +1992,7 @@ void MM_FillDumpInEventBuffer_Test_BadType(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillDumpInEventBuffer_Test_RAM */
+}
 
 void MM_FillDumpInEventBuffer_Test_EEPROM(void)
 {
@@ -2057,8 +2019,7 @@ void MM_FillDumpInEventBuffer_Test_EEPROM(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillDumpInEventBuffer_Test_EEPROM */
+}
 
 void MM_FillDumpInEventBuffer_Test_MEM32(void)
 {
@@ -2085,8 +2046,7 @@ void MM_FillDumpInEventBuffer_Test_MEM32(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillDumpInEventBuffer_Test_MEM32 */
+}
 
 void MM_FillDumpInEventBuffer_Test_MEM16(void)
 {
@@ -2113,8 +2073,7 @@ void MM_FillDumpInEventBuffer_Test_MEM16(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillDumpInEventBuffer_Test_MEM16 */
+}
 
 void MM_FillDumpInEventBuffer_Test_MEM8(void)
 {
@@ -2140,8 +2099,7 @@ void MM_FillDumpInEventBuffer_Test_MEM8(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillDumpInEventBuffer_Test_MEM8 */
+}
 
 void MM_FillDumpInEventBuffer_Test_MEM32ReadError(void)
 {
@@ -2182,8 +2140,7 @@ void MM_FillDumpInEventBuffer_Test_MEM32ReadError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillDumpInEventBuffer_Test_MEM32ReadError */
+}
 
 void MM_FillDumpInEventBuffer_Test_MEM16ReadError(void)
 {
@@ -2224,8 +2181,7 @@ void MM_FillDumpInEventBuffer_Test_MEM16ReadError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillDumpInEventBuffer_Test_MEM16ReadError */
+}
 
 void MM_FillDumpInEventBuffer_Test_MEM8ReadError(void)
 {
@@ -2266,8 +2222,7 @@ void MM_FillDumpInEventBuffer_Test_MEM8ReadError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillDumpInEventBuffer_Test_MEM8ReadError */
+}
 
 /*
  * Register the test cases to execute with the unit test tool
@@ -2350,8 +2305,4 @@ void UtTest_Setup(void)
                "MM_FillDumpInEventBuffer_Test_MEM16ReadError");
     UtTest_Add(MM_FillDumpInEventBuffer_Test_MEM8ReadError, MM_Test_Setup, MM_Test_TearDown,
                "MM_FillDumpInEventBuffer_Test_MEM8ReadError");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/mm_load_tests.c
+++ b/unit-test/mm_load_tests.c
@@ -69,7 +69,7 @@ int32 UT_MM_LOAD_TEST_MM_FillMemHook1(void *UserObj, int32 StubRetcode, uint32 C
     MM_AppData.HkPacket.LastAction = MM_FILL;
 
     return true;
-} /* end UT_MM_LOAD_TEST_MM_FillMemHook1 */
+}
 
 int32 UT_MM_LOAD_TEST_MM_ComputeCrcHook1(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                          const UT_StubContext_t *Context)
@@ -82,7 +82,7 @@ int32 UT_MM_LOAD_TEST_MM_ComputeCrcHook1(void *UserObj, int32 StubRetcode, uint3
     }
 
     return OS_SUCCESS;
-} /* end UT_MM_LOAD_TEST_MM_ComputeCrcHook1 */
+}
 
 int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook1(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                             const UT_StubContext_t *Context)
@@ -95,7 +95,7 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook1(void *UserObj, int32 StubRetcode, ui
     *MMHeaderRestore = MMHeaderSave;
 
     return true;
-} /* end UT_MM_LOAD_TEST_CFE_SymbolLookupHook1 */
+}
 
 int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook2(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                             const UT_StubContext_t *Context)
@@ -108,7 +108,7 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook2(void *UserObj, int32 StubRetcode, ui
     *MMHeaderRestore = MMHeaderSave;
 
     return false;
-} /* end UT_MM_LOAD_TEST_CFE_SymbolLookupHook2 */
+}
 
 int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook3(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                             const UT_StubContext_t *Context)
@@ -118,7 +118,7 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook3(void *UserObj, int32 StubRetcode, ui
     *ResolvedAddress = (cpuaddr)DummyBuffer;
 
     return true;
-} /* end UT_MM_LOAD_TEST_CFE_SymbolLookupHook3 */
+}
 
 int8  UT_MM_CFE_OS_ReadHook1_MemType;
 int32 UT_MM_CFE_OS_ReadHook_RunCount;
@@ -150,7 +150,7 @@ int32 UT_MM_CFE_OS_ReadHook1(void *UserObj, int32 StubRetcode, uint32 CallCount,
     {
         return 0;
     }
-} /* end UT_MM_CFE_OS_ReadHook1 */
+}
 
 int32 UT_MM_CFE_OS_ReadHook2(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
 {
@@ -168,8 +168,7 @@ int32 UT_MM_CFE_OS_ReadHook2(void *UserObj, int32 StubRetcode, uint32 CallCount,
     MMHeaderSave    = *header;
 
     return sizeof(MM_LoadDumpFileHeader_t);
-
-} /* end UT_MM_CFE_OS_ReadHook2 */
+}
 
 int32 UT_MM_CFE_OS_ReadHook3(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
 {
@@ -187,8 +186,7 @@ int32 UT_MM_CFE_OS_ReadHook3(void *UserObj, int32 StubRetcode, uint32 CallCount,
     MMHeaderSave    = *header;
 
     return sizeof(MM_LoadDumpFileHeader_t);
-
-} /* end UT_MM_CFE_OS_ReadHook2 */
+}
 
 int32 UT_MM_LOAD_TEST_CFE_OS_StatHook1(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                        const UT_StubContext_t *Context)
@@ -199,7 +197,7 @@ int32 UT_MM_LOAD_TEST_CFE_OS_StatHook1(void *UserObj, int32 StubRetcode, uint32 
     UT_SetDataBuffer(UT_KEY(OS_stat), &filestats, sizeof(filestats), true);
 
     return OS_SUCCESS;
-} /* end UT_MM_LOAD_TEST_CFE_OS_StatHook1 */
+}
 
 void MM_PokeCmd_Test_EEPROM(void)
 {
@@ -246,8 +244,7 @@ void MM_PokeCmd_Test_EEPROM(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeCmd_Test_EEPROM */
+}
 
 void MM_PokeCmd_Test_NonEEPROM(void)
 {
@@ -294,8 +291,7 @@ void MM_PokeCmd_Test_NonEEPROM(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeCmd_Test_NonEEPROM */
+}
 
 void MM_PokeCmd_Test_SymNameError(void)
 {
@@ -340,8 +336,7 @@ void MM_PokeCmd_Test_SymNameError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeCmd_Test_SymNameError */
+}
 
 void MM_PokeCmd_Test_NoVerifyCmdLength(void)
 {
@@ -362,8 +357,7 @@ void MM_PokeCmd_Test_NoVerifyCmdLength(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeCmd_Test_NoVerifyCmdLength */
+}
 
 void MM_PokeCmd_Test_NoVerifyPeekPokeParams(void)
 {
@@ -398,8 +392,7 @@ void MM_PokeCmd_Test_NoVerifyPeekPokeParams(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeCmd_Test_NoVerifyPeekPokeParams */
+}
 
 void MM_PokeMem_Test_NoDataSize(void)
 {
@@ -425,8 +418,7 @@ void MM_PokeMem_Test_NoDataSize(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeMem_Test_8bit */
+}
 
 void MM_PokeMem_Test_8bit(void)
 {
@@ -472,8 +464,7 @@ void MM_PokeMem_Test_8bit(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeMem_Test_8bit */
+}
 
 void MM_PokeMem_Test_8bitError(void)
 {
@@ -517,8 +508,7 @@ void MM_PokeMem_Test_8bitError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeMem_Test_8bitError */
+}
 
 void MM_PokeMem_Test_16bit(void)
 {
@@ -564,8 +554,7 @@ void MM_PokeMem_Test_16bit(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeMem_Test_16bit */
+}
 
 void MM_PokeMem_Test_16bitError(void)
 {
@@ -609,8 +598,7 @@ void MM_PokeMem_Test_16bitError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeMem_Test_16bitError */
+}
 
 void MM_PokeMem_Test_32bit(void)
 {
@@ -656,8 +644,7 @@ void MM_PokeMem_Test_32bit(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeMem_Test_32bit */
+}
 
 void MM_PokeMem_Test_32bitError(void)
 {
@@ -701,8 +688,7 @@ void MM_PokeMem_Test_32bitError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeMem_Test_32bitError */
+}
 
 void MM_PokeEeprom_Test_NoDataSize(void)
 {
@@ -729,8 +715,7 @@ void MM_PokeEeprom_Test_NoDataSize(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeMem_Test_8bit */
+}
 
 void MM_PokeEeprom_Test_8bit(void)
 {
@@ -776,8 +761,7 @@ void MM_PokeEeprom_Test_8bit(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeEeprom_Test_8bit */
+}
 
 void MM_PokeEeprom_Test_8bitError(void)
 {
@@ -821,8 +805,7 @@ void MM_PokeEeprom_Test_8bitError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeEeprom_Test_8bitError */
+}
 
 void MM_PokeEeprom_Test_16bit(void)
 {
@@ -868,8 +851,7 @@ void MM_PokeEeprom_Test_16bit(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeEeprom_Test_16bit */
+}
 
 void MM_PokeEeprom_Test_16bitError(void)
 {
@@ -913,8 +895,7 @@ void MM_PokeEeprom_Test_16bitError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeEeprom_Test_16bitError */
+}
 
 void MM_PokeEeprom_Test_32bit(void)
 {
@@ -960,8 +941,7 @@ void MM_PokeEeprom_Test_32bit(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeEeprom_Test_32bit */
+}
 
 void MM_PokeEeprom_Test_32bitError(void)
 {
@@ -1005,8 +985,7 @@ void MM_PokeEeprom_Test_32bitError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_PokeEeprom_Test_32bitError */
+}
 
 void MM_LoadMemWIDCmd_Test_Nominal(void)
 {
@@ -1061,8 +1040,7 @@ void MM_LoadMemWIDCmd_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemWIDCmd_Test_Nominal */
+}
 
 void MM_LoadMemWIDCmd_Test_NoVerifyCmdLength(void)
 {
@@ -1083,8 +1061,7 @@ void MM_LoadMemWIDCmd_Test_NoVerifyCmdLength(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemWIDCmd_Test_NoVerifyCmdLength */
+}
 
 void MM_LoadMemWIDCmd_Test_CRCError(void)
 {
@@ -1136,8 +1113,7 @@ void MM_LoadMemWIDCmd_Test_CRCError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemWIDCmd_Test_CRCError */
+}
 
 void MM_LoadMemWIDCmd_Test_SymNameErr(void)
 {
@@ -1189,8 +1165,7 @@ void MM_LoadMemWIDCmd_Test_SymNameErr(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemWIDCmd_Test_SymNameErr */
+}
 
 void MM_LoadMemWIDCmd_Test_NoVerifyLoadWIDParams(void)
 {
@@ -1230,8 +1205,7 @@ void MM_LoadMemWIDCmd_Test_NoVerifyLoadWIDParams(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadWIDParams_Test_Nominal */
+}
 
 void MM_LoadMemFromFileCmd_Test_RAM(void)
 {
@@ -1289,8 +1263,7 @@ void MM_LoadMemFromFileCmd_Test_RAM(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_RAM */
+}
 
 void MM_LoadMemFromFileCmd_Test_BadType(void)
 {
@@ -1333,8 +1306,7 @@ void MM_LoadMemFromFileCmd_Test_BadType(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_BadType */
+}
 
 void MM_LoadMemFromFileCmd_Test_EEPROM(void)
 {
@@ -1389,8 +1361,7 @@ void MM_LoadMemFromFileCmd_Test_EEPROM(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_EEPROM */
+}
 
 void MM_LoadMemFromFileCmd_Test_MEM32(void)
 {
@@ -1447,8 +1418,7 @@ void MM_LoadMemFromFileCmd_Test_MEM32(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_MEM32 */
+}
 
 void MM_LoadMemFromFileCmd_Test_MEM32Invalid(void)
 {
@@ -1493,8 +1463,7 @@ void MM_LoadMemFromFileCmd_Test_MEM32Invalid(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_MEM32 */
+}
 
 void MM_LoadMemFromFileCmd_Test_MEM16(void)
 {
@@ -1552,8 +1521,7 @@ void MM_LoadMemFromFileCmd_Test_MEM16(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_MEM16 */
+}
 
 void MM_LoadMemFromFileCmd_Test_MEM8(void)
 {
@@ -1609,8 +1577,7 @@ void MM_LoadMemFromFileCmd_Test_MEM8(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_MEM8 */
+}
 
 void MM_LoadMemFromFileCmd_Test_NoVerifyCmdLength(void)
 {
@@ -1632,8 +1599,7 @@ void MM_LoadMemFromFileCmd_Test_NoVerifyCmdLength(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_NoVerifyCmdLength */
+}
 
 void MM_LoadMemFromFileCmd_Test_NoReadFileHeaders(void)
 {
@@ -1689,8 +1655,7 @@ void MM_LoadMemFromFileCmd_Test_NoReadFileHeaders(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_NoReadFileHeaders */
+}
 
 void MM_LoadMemFromFileCmd_Test_NoVerifyLoadFileSize(void)
 {
@@ -1740,8 +1705,7 @@ void MM_LoadMemFromFileCmd_Test_NoVerifyLoadFileSize(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_NoVerifyLoadFileSize */
+}
 
 void MM_LoadMemFromFileCmd_Test_lseekError(void)
 {
@@ -1798,8 +1762,7 @@ void MM_LoadMemFromFileCmd_Test_lseekError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_NoValidMemType */
+}
 
 void MM_LoadMemFromFileCmd_Test_LoadParamsError(void)
 {
@@ -1854,8 +1817,7 @@ void MM_LoadMemFromFileCmd_Test_LoadParamsError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_LoadParamsError */
+}
 
 void MM_LoadMemFromFileCmd_Test_SymNameError(void)
 {
@@ -1911,8 +1873,7 @@ void MM_LoadMemFromFileCmd_Test_SymNameError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_SymNameError */
+}
 
 void MM_LoadMemFromFileCmd_Test_LoadFileCRCError(void)
 {
@@ -1972,8 +1933,7 @@ void MM_LoadMemFromFileCmd_Test_LoadFileCRCError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_LoadFileCRCError */
+}
 
 void MM_LoadMemFromFileCmd_Test_ComputeCRCError(void)
 {
@@ -2024,8 +1984,7 @@ void MM_LoadMemFromFileCmd_Test_ComputeCRCError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_ComputeCRCError */
+}
 
 void MM_LoadMemFromFileCmd_Test_CloseError(void)
 {
@@ -2082,8 +2041,7 @@ void MM_LoadMemFromFileCmd_Test_CloseError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_CloseError */
+}
 
 void MM_LoadMemFromFileCmd_Test_OpenError(void)
 {
@@ -2131,8 +2089,7 @@ void MM_LoadMemFromFileCmd_Test_OpenError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFileCmd_Test_OpenError */
+}
 
 void MM_LoadMemFromFile_Test_PreventCPUHogging(void)
 {
@@ -2167,8 +2124,7 @@ void MM_LoadMemFromFile_Test_PreventCPUHogging(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFile_Test_PreventCPUHogging */
+}
 
 void MM_LoadMemFromFile_Test_ReadError(void)
 {
@@ -2205,8 +2161,7 @@ void MM_LoadMemFromFile_Test_ReadError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFile_Test_ReadError */
+}
 
 void MM_LoadMemFromFile_Test_NotEepromMemType(void)
 {
@@ -2241,8 +2196,7 @@ void MM_LoadMemFromFile_Test_NotEepromMemType(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMemFromFile_Test_NotEepromMemType */
+}
 
 void MM_ReadFileHeaders_Test_ReadHeaderError(void)
 {
@@ -2279,8 +2233,7 @@ void MM_ReadFileHeaders_Test_ReadHeaderError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_ReadFileHeaders_Test_ReadHeaderError */
+}
 
 void MM_ReadFileHeaders_Test_ReadError(void)
 {
@@ -2317,8 +2270,7 @@ void MM_ReadFileHeaders_Test_ReadError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_ReadFileHeaders_Test_ReadError */
+}
 
 void MM_VerifyLoadFileSize_Test_StatError(void)
 {
@@ -2353,8 +2305,7 @@ void MM_VerifyLoadFileSize_Test_StatError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadFileSize_Test_StatError */
+}
 
 void MM_VerifyLoadFileSize_Test_SizeError(void)
 {
@@ -2391,8 +2342,7 @@ void MM_VerifyLoadFileSize_Test_SizeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadFileSize_Test_SizeError */
+}
 
 void MM_FillMemCmd_Test_RAM(void)
 {
@@ -2435,8 +2385,7 @@ void MM_FillMemCmd_Test_RAM(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMemCmd_Test_RAM */
+}
 
 void MM_FillMemCmd_Test_EEPROM(void)
 {
@@ -2479,8 +2428,7 @@ void MM_FillMemCmd_Test_EEPROM(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMemCmd_Test_EEPROM */
+}
 
 void MM_FillMemCmd_Test_MEM32(void)
 {
@@ -2525,8 +2473,7 @@ void MM_FillMemCmd_Test_MEM32(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMemCmd_Test_MEM32 */
+}
 
 void MM_FillMemCmd_Test_MEM16(void)
 {
@@ -2571,8 +2518,7 @@ void MM_FillMemCmd_Test_MEM16(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMemCmd_Test_MEM16 */
+}
 
 void MM_FillMemCmd_Test_MEM8(void)
 {
@@ -2615,8 +2561,7 @@ void MM_FillMemCmd_Test_MEM8(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMemCmd_Test_MEM8 */
+}
 
 void MM_FillMemCmd_Test_SymNameError(void)
 {
@@ -2655,8 +2600,7 @@ void MM_FillMemCmd_Test_SymNameError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMemCmd_Test_SymNameError */
+}
 
 void MM_FillMemCmd_Test_NoVerifyCmdLength(void)
 {
@@ -2680,8 +2624,7 @@ void MM_FillMemCmd_Test_NoVerifyCmdLength(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMemCmd_Test_NoVerifyCmdLength */
+}
 
 void MM_FillMemCmd_Test_NoLastActionFill(void)
 {
@@ -2709,8 +2652,7 @@ void MM_FillMemCmd_Test_NoLastActionFill(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMemCmd_Test_NoLastActionFill */
+}
 
 void MM_FillMemCmd_Test_NoVerifyLoadDump(void)
 {
@@ -2738,8 +2680,7 @@ void MM_FillMemCmd_Test_NoVerifyLoadDump(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMemCmd_Test_NoVerifyLoadDump */
+}
 
 void MM_FillMemCmd_Test_BadType(void)
 {
@@ -2766,8 +2707,7 @@ void MM_FillMemCmd_Test_BadType(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMemCmd_Test_RAM */
+}
 
 void MM_FillMem_Test_Nominal(void)
 {
@@ -2801,8 +2741,7 @@ void MM_FillMem_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem_Test_Nominal */
+}
 
 void MM_FillMem_Test_MaxFillDataSegment(void)
 {
@@ -2837,8 +2776,7 @@ void MM_FillMem_Test_MaxFillDataSegment(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem_Test_MaxFillDataSegment */
+}
 
 /*
  * Register the test cases to execute with the unit test tool
@@ -2935,9 +2873,4 @@ void UtTest_Setup(void)
     UtTest_Add(MM_FillMem_Test_Nominal, MM_Test_Setup, MM_Test_TearDown, "MM_FillMem_Test_Nominal");
     UtTest_Add(MM_FillMem_Test_MaxFillDataSegment, MM_Test_Setup, MM_Test_TearDown,
                "MM_FillMem_Test_MaxFillDataSegment");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/mm_mem16_tests.c
+++ b/unit-test/mm_mem16_tests.c
@@ -87,8 +87,7 @@ void MM_LoadMem16FromFile_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem16FromFile_Test_Nominal */
+}
 
 void MM_LoadMem16FromFile_Test_CPUHogging(void)
 {
@@ -124,8 +123,7 @@ void MM_LoadMem16FromFile_Test_CPUHogging(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem16FromFile_Test_CPUHogging */
+}
 
 void MM_LoadMem16FromFile_Test_ReadError(void)
 {
@@ -165,8 +163,7 @@ void MM_LoadMem16FromFile_Test_ReadError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem16FromFile_Test_ReadError */
+}
 
 void MM_LoadMem16FromFile_Test_WriteError(void)
 {
@@ -212,8 +209,7 @@ void MM_LoadMem16FromFile_Test_WriteError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem16FromFile_Test_WriteError */
+}
 
 void MM_DumpMem16ToFile_Test_Nominal(void)
 {
@@ -248,8 +244,7 @@ void MM_DumpMem16ToFile_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem16ToFile_Test_Nominal */
+}
 
 void MM_DumpMem16ToFile_Test_CPUHogging(void)
 {
@@ -284,8 +279,7 @@ void MM_DumpMem16ToFile_Test_CPUHogging(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem16ToFile_Test_CPUHogging */
+}
 
 void MM_DumpMem16ToFile_Test_ReadError(void)
 {
@@ -326,8 +320,7 @@ void MM_DumpMem16ToFile_Test_ReadError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem16ToFile_Test_ReadError */
+}
 
 void MM_DumpMem16ToFile_Test_WriteError(void)
 {
@@ -368,8 +361,7 @@ void MM_DumpMem16ToFile_Test_WriteError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem16ToFile_Test_WriteError */
+}
 
 void MM_FillMem16_Test_Nominal(void)
 {
@@ -400,8 +392,7 @@ void MM_FillMem16_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem16_Test_Nominal */
+}
 
 void MM_FillMem16_Test_CPUHogging(void)
 {
@@ -433,8 +424,7 @@ void MM_FillMem16_Test_CPUHogging(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem16_Test_CPUHogging */
+}
 
 void MM_FillMem16_Test_WriteError(void)
 {
@@ -474,8 +464,7 @@ void MM_FillMem16_Test_WriteError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem16_Test_WriteError */
+}
 
 void MM_FillMem16_Test_Align(void)
 {
@@ -511,8 +500,7 @@ void MM_FillMem16_Test_Align(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem16_Test_Align */
+}
 
 /*
  * Register the test cases to execute with the unit test tool
@@ -536,8 +524,4 @@ void UtTest_Setup(void)
     UtTest_Add(MM_FillMem16_Test_CPUHogging, MM_Test_Setup, MM_Test_TearDown, "MM_FillMem16_Test_CPUHogging");
     UtTest_Add(MM_FillMem16_Test_WriteError, MM_Test_Setup, MM_Test_TearDown, "MM_FillMem16_Test_WriteError");
     UtTest_Add(MM_FillMem16_Test_Align, MM_Test_Setup, MM_Test_TearDown, "MM_FillMem16_Test_Align");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/mm_mem32_tests.c
+++ b/unit-test/mm_mem32_tests.c
@@ -87,8 +87,7 @@ void MM_LoadMem32FromFile_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem32FromFile_Test_Nominal */
+}
 
 void MM_LoadMem32FromFile_Test_CPUHogging(void)
 {
@@ -124,8 +123,7 @@ void MM_LoadMem32FromFile_Test_CPUHogging(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem32FromFile_Test_CPUHogging */
+}
 
 void MM_LoadMem32FromFile_Test_ReadError(void)
 {
@@ -165,8 +163,7 @@ void MM_LoadMem32FromFile_Test_ReadError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem32FromFile_Test_ReadError */
+}
 
 void MM_LoadMem32FromFile_Test_WriteError(void)
 {
@@ -212,8 +209,7 @@ void MM_LoadMem32FromFile_Test_WriteError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem32FromFile_Test_WriteError */
+}
 
 void MM_DumpMem32ToFile_Test_Nominal(void)
 {
@@ -250,8 +246,7 @@ void MM_DumpMem32ToFile_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem32ToFile_Test_Nominal */
+}
 
 void MM_DumpMem32ToFile_Test_CPUHogging(void)
 {
@@ -286,8 +281,7 @@ void MM_DumpMem32ToFile_Test_CPUHogging(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem32ToFile_Test_CPUHogging */
+}
 
 void MM_DumpMem32ToFile_Test_ReadError(void)
 {
@@ -328,8 +322,7 @@ void MM_DumpMem32ToFile_Test_ReadError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem32ToFile_Test_ReadError */
+}
 
 void MM_DumpMem32ToFile_Test_WriteError(void)
 {
@@ -370,8 +363,7 @@ void MM_DumpMem32ToFile_Test_WriteError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem32ToFile_Test_WriteError */
+}
 
 void MM_FillMem32_Test_Nominal(void)
 {
@@ -403,8 +395,7 @@ void MM_FillMem32_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem32_Test_Nominal */
+}
 
 void MM_FillMem32_Test_CPUHogging(void)
 {
@@ -436,8 +427,7 @@ void MM_FillMem32_Test_CPUHogging(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem32_Test_CPUHogging */
+}
 
 void MM_FillMem32_Test_WriteError(void)
 {
@@ -477,8 +467,7 @@ void MM_FillMem32_Test_WriteError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem32_Test_WriteError */
+}
 
 void MM_FillMem32_Test_Align(void)
 {
@@ -514,8 +503,7 @@ void MM_FillMem32_Test_Align(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem32_Test_Align */
+}
 
 /*
  * Register the test cases to execute with the unit test tool
@@ -539,8 +527,4 @@ void UtTest_Setup(void)
     UtTest_Add(MM_FillMem32_Test_CPUHogging, MM_Test_Setup, MM_Test_TearDown, "MM_FillMem32_Test_CPUHogging");
     UtTest_Add(MM_FillMem32_Test_WriteError, MM_Test_Setup, MM_Test_TearDown, "MM_FillMem32_Test_WriteError");
     UtTest_Add(MM_FillMem32_Test_Align, MM_Test_Setup, MM_Test_TearDown, "MM_FillMem32_Test_Align");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/mm_mem8_tests.c
+++ b/unit-test/mm_mem8_tests.c
@@ -87,8 +87,7 @@ void MM_LoadMem8FromFile_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem8FromFile_Test_Nominal */
+}
 
 void MM_LoadMem8FromFile_Test_CPUHogging(void)
 {
@@ -124,8 +123,7 @@ void MM_LoadMem8FromFile_Test_CPUHogging(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem8FromFile_Test_CPUHogging */
+}
 
 void MM_LoadMem8FromFile_Test_ReadError(void)
 {
@@ -165,8 +163,7 @@ void MM_LoadMem8FromFile_Test_ReadError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem8FromFile_Test_ReadError */
+}
 
 void MM_LoadMem8FromFile_Test_WriteError(void)
 {
@@ -212,8 +209,7 @@ void MM_LoadMem8FromFile_Test_WriteError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_LoadMem8FromFile_Test_WriteError */
+}
 
 void MM_DumpMem8ToFile_Test_Nominal(void)
 {
@@ -250,8 +246,7 @@ void MM_DumpMem8ToFile_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem8ToFile_Test_Nominal */
+}
 
 void MM_DumpMem8ToFile_Test_CPUHogging(void)
 {
@@ -286,8 +281,7 @@ void MM_DumpMem8ToFile_Test_CPUHogging(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem8ToFile_Test_CPUHogging */
+}
 
 void MM_DumpMem8ToFile_Test_ReadError(void)
 {
@@ -328,8 +322,7 @@ void MM_DumpMem8ToFile_Test_ReadError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem8ToFile_Test_ReadError */
+}
 
 void MM_DumpMem8ToFile_Test_WriteError(void)
 {
@@ -370,8 +363,7 @@ void MM_DumpMem8ToFile_Test_WriteError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_DumpMem8ToFile_Test_WriteError */
+}
 
 void MM_FillMem8_Test_Nominal(void)
 {
@@ -403,8 +395,7 @@ void MM_FillMem8_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem8_Test_Nominal */
+}
 
 void MM_FillMem8_Test_CPUHogging(void)
 {
@@ -435,8 +426,7 @@ void MM_FillMem8_Test_CPUHogging(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem8_Test_CPUHogging */
+}
 
 void MM_FillMem8_Test_WriteError(void)
 {
@@ -477,8 +467,7 @@ void MM_FillMem8_Test_WriteError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_FillMem8_Test_WriteError */
+}
 
 /*
  * Register the test cases to execute with the unit test tool
@@ -499,8 +488,4 @@ void UtTest_Setup(void)
     UtTest_Add(MM_FillMem8_Test_Nominal, MM_Test_Setup, MM_Test_TearDown, "MM_FillMem8_Test_Nominal");
     UtTest_Add(MM_FillMem8_Test_CPUHogging, MM_Test_Setup, MM_Test_TearDown, "MM_FillMem8_Test_CPUHogging");
     UtTest_Add(MM_FillMem8_Test_WriteError, MM_Test_Setup, MM_Test_TearDown, "MM_FillMem8_Test_WriteError");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/mm_utils_tests.c
+++ b/unit-test/mm_utils_tests.c
@@ -84,8 +84,7 @@ void MM_ResetHk_Test(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_ResetHk_Test */
+}
 
 void MM_VerifyCmdLength_Test_Nominal(void)
 {
@@ -116,8 +115,7 @@ void MM_VerifyCmdLength_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyCmdLength_Test_Nominal */
+}
 
 void MM_VerifyCmdLength_Test_HKRequestLengthError(void)
 {
@@ -157,8 +155,7 @@ void MM_VerifyCmdLength_Test_HKRequestLengthError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyCmdLength_Test_HKRequestLengthError */
+}
 
 void MM_VerifyCmdLength_Test_LengthError(void)
 {
@@ -198,8 +195,7 @@ void MM_VerifyCmdLength_Test_LengthError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyCmdLength_Test_LengthError */
+}
 
 void MM_SegmentBreak_Test_Nominal(void)
 {
@@ -216,8 +212,7 @@ void MM_SegmentBreak_Test_Nominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_SegmentBreak_Test_Nominal */
+}
 
 void MM_VerifyPeekPokeParams_Test_ByteWidthRAM(void)
 {
@@ -240,8 +235,7 @@ void MM_VerifyPeekPokeParams_Test_ByteWidthRAM(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_ByteWidthRAM */
+}
 
 void MM_VerifyPeekPokeParams_Test_WordWidthMEM16(void)
 {
@@ -264,8 +258,7 @@ void MM_VerifyPeekPokeParams_Test_WordWidthMEM16(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_WordWidthMEM16 */
+}
 
 void MM_VerifyPeekPokeParams_Test_DWordWidthMEM32(void)
 {
@@ -288,8 +281,7 @@ void MM_VerifyPeekPokeParams_Test_DWordWidthMEM32(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_DWordWidthMEM32 */
+}
 
 void MM_VerifyPeekPokeParams_Test_WordWidthAlignmentError(void)
 {
@@ -324,8 +316,7 @@ void MM_VerifyPeekPokeParams_Test_WordWidthAlignmentError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_WordWidthAlignmentError */
+}
 
 void MM_VerifyPeekPokeParams_Test_DWordWidthAlignmentError(void)
 {
@@ -360,8 +351,7 @@ void MM_VerifyPeekPokeParams_Test_DWordWidthAlignmentError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_DWordWidthAlignmentError */
+}
 
 void MM_VerifyPeekPokeParams_Test_InvalidDataSize(void)
 {
@@ -396,8 +386,7 @@ void MM_VerifyPeekPokeParams_Test_InvalidDataSize(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_InvalidDataSize */
+}
 
 void MM_VerifyPeekPokeParams_Test_EEPROM(void)
 {
@@ -420,8 +409,7 @@ void MM_VerifyPeekPokeParams_Test_EEPROM(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_EEPROM */
+}
 
 void MM_VerifyPeekPokeParams_Test_MEM8(void)
 {
@@ -444,8 +432,7 @@ void MM_VerifyPeekPokeParams_Test_MEM8(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_MEM8 */
+}
 
 void MM_VerifyPeekPokeParams_Test_RAMValidateRangeError(void)
 {
@@ -483,8 +470,7 @@ void MM_VerifyPeekPokeParams_Test_RAMValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_RAMValidateRangeError */
+}
 
 void MM_VerifyPeekPokeParams_Test_EEPROMValidateRangeError(void)
 {
@@ -522,8 +508,7 @@ void MM_VerifyPeekPokeParams_Test_EEPROMValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_EEPROMValidateRangeError */
+}
 
 void MM_VerifyPeekPokeParams_Test_MEM32ValidateRangeError(void)
 {
@@ -561,8 +546,7 @@ void MM_VerifyPeekPokeParams_Test_MEM32ValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_MEM32ValidateRangeError */
+}
 
 void MM_VerifyPeekPokeParams_Test_MEM16ValidateRangeError(void)
 {
@@ -600,8 +584,7 @@ void MM_VerifyPeekPokeParams_Test_MEM16ValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_MEM16ValidateRangeError */
+}
 
 void MM_VerifyPeekPokeParams_Test_MEM8ValidateRangeError(void)
 {
@@ -639,8 +622,7 @@ void MM_VerifyPeekPokeParams_Test_MEM8ValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_MEM8ValidateRangeError */
+}
 
 void MM_VerifyPeekPokeParams_Test_MEM32InvalidDataSize(void)
 {
@@ -674,8 +656,7 @@ void MM_VerifyPeekPokeParams_Test_MEM32InvalidDataSize(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_MEM32InvalidDataSize */
+}
 
 void MM_VerifyPeekPokeParams_Test_MEM16InvalidDataSize(void)
 {
@@ -709,8 +690,7 @@ void MM_VerifyPeekPokeParams_Test_MEM16InvalidDataSize(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_MEM16InvalidDataSize */
+}
 
 void MM_VerifyPeekPokeParams_Test_MEM8InvalidDataSize(void)
 {
@@ -744,8 +724,7 @@ void MM_VerifyPeekPokeParams_Test_MEM8InvalidDataSize(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_MEM8InvalidDataSize */
+}
 
 void MM_VerifyPeekPokeParams_Test_InvalidMemType(void)
 {
@@ -779,8 +758,7 @@ void MM_VerifyPeekPokeParams_Test_InvalidMemType(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyPeekPokeParams_Test_InvalidMemType */
+}
 
 /*************************************/
 /* MM_VerifyLoadDumpParams Tests */
@@ -822,8 +800,7 @@ void MM_VerifyLoadDumpParams_Test_LoadRAMValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadRAMValidateRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooSmall(void)
 {
@@ -857,8 +834,7 @@ void MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooLarge(void)
 {
@@ -892,8 +868,7 @@ void MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadEEPROMValidateRangeError(void)
 {
@@ -930,8 +905,7 @@ void MM_VerifyLoadDumpParams_Test_LoadEEPROMValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadEEPROMValidateRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooSmall(void)
 {
@@ -965,8 +939,7 @@ void MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooLarge(void)
 {
@@ -1000,8 +973,7 @@ void MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM32ValidateRangeError(void)
 {
@@ -1038,8 +1010,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32ValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadMEM32ValidateRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooSmall(void)
 {
@@ -1073,8 +1044,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooLarge(void)
 {
@@ -1108,8 +1078,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM32AlignmentError(void)
 {
@@ -1143,8 +1112,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32AlignmentError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadMEM32AlignmentError */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM16ValidateRangeError(void)
 {
@@ -1181,8 +1149,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16ValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_MEM16ValidateRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooSmall(void)
 {
@@ -1216,8 +1183,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooLarge(void)
 {
@@ -1251,8 +1217,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM16AlignmentError(void)
 {
@@ -1286,8 +1251,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16AlignmentError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadMEM16AlignmentError */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM8ValidateRangeError(void)
 {
@@ -1324,8 +1288,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM8ValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadMEM8ValidateRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooSmall(void)
 {
@@ -1359,8 +1322,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooLarge(void)
 {
@@ -1394,8 +1356,7 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadInvalidMemTypeError(void)
 {
@@ -1428,8 +1389,7 @@ void MM_VerifyLoadDumpParams_Test_LoadInvalidMemTypeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadInvalidMemTypeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_LoadInvalidVerifyTypeError(void)
 {
@@ -1451,8 +1411,7 @@ void MM_VerifyLoadDumpParams_Test_LoadInvalidVerifyTypeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_LoadInvalidVerifyTypeError */
+}
 
 /* Dumping */
 void MM_VerifyLoadDumpParams_Test_DumpRAM(void)
@@ -1476,8 +1435,7 @@ void MM_VerifyLoadDumpParams_Test_DumpRAM(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpRAM */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEEPROM(void)
 {
@@ -1500,8 +1458,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROM(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEEPROM */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM32(void)
 {
@@ -1526,8 +1483,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM32 */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM16(void)
 {
@@ -1552,8 +1508,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM16 */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM8(void)
 {
@@ -1578,8 +1533,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM8 */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpRAMRangeError(void)
 {
@@ -1617,8 +1571,7 @@ void MM_VerifyLoadDumpParams_Test_DumpRAMRangeError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpRAMRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooSmall(void)
 {
@@ -1653,8 +1606,7 @@ void MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooSmall(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooLarge(void)
 {
@@ -1689,8 +1641,7 @@ void MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooLarge(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEEPROMRangeError(void)
 {
@@ -1728,8 +1679,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROMRangeError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEEPROMRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooSmall(void)
 {
@@ -1764,8 +1714,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooSmall(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooLarge(void)
 {
@@ -1800,8 +1749,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooLarge(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM32RangeError(void)
 {
@@ -1839,8 +1787,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32RangeError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM32RangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooSmall(void)
 {
@@ -1875,8 +1822,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooSmall(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooLarge(void)
 {
@@ -1911,8 +1857,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooLarge(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM32AlignmentError(void)
 {
@@ -1947,8 +1892,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32AlignmentError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM32AlignmentError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM16RangeError(void)
 {
@@ -1986,8 +1930,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16RangeError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM16RangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooSmall(void)
 {
@@ -2022,8 +1965,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooSmall(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooLarge(void)
 {
@@ -2058,8 +2000,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooLarge(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM16AlignmentError(void)
 {
@@ -2094,8 +2035,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16AlignmentError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM16AlignmentError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM8RangeError(void)
 {
@@ -2133,8 +2073,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8RangeError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM8RangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooSmall(void)
 {
@@ -2169,8 +2108,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooSmall(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooLarge(void)
 {
@@ -2205,8 +2143,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooLarge(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpInvalidMemoryType(void)
 {
@@ -2243,8 +2180,7 @@ void MM_VerifyLoadDumpParams_Test_DumpInvalidMemoryType(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpInvalidMemoryType */
+}
 
 /* Dump in event */
 
@@ -2269,8 +2205,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventRAM(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventRAM */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventEEPROM(void)
 {
@@ -2293,8 +2228,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventEEPROM(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventEEPROM */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM32(void)
 {
@@ -2317,8 +2251,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventMEM32 */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM16(void)
 {
@@ -2341,8 +2274,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventMEM16 */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM8(void)
 {
@@ -2365,8 +2297,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM8(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventMEM8 */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooSmall(void)
 {
@@ -2401,8 +2332,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooSmall(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooLarge(void)
 {
@@ -2437,8 +2367,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooLarge(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventRAMRangeError(void)
 {
@@ -2476,8 +2405,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventRAMRangeError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventRAMRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventEEPROMRangeError(void)
 {
@@ -2515,8 +2443,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventEEPROMRangeError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventEEPROMRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM32RangeError(void)
 {
@@ -2554,8 +2481,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32RangeError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventMEM32RangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM32AlignmentError(void)
 {
@@ -2590,8 +2516,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32AlignmentError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventMEM32AlignmentError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM16RangeError(void)
 {
@@ -2629,8 +2554,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16RangeError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventMEM16RangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM16AlignmentError(void)
 {
@@ -2665,8 +2589,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16AlignmentError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventMEM16AlignmentError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM8RangeError(void)
 {
@@ -2704,8 +2627,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM8RangeError(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventMEM32RangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_DumpEventInvalidMemType(void)
 {
@@ -2742,8 +2664,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventInvalidMemType(void)
     /* no command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_DumpEventInvalidMemType */
+}
 
 /* Fill */
 
@@ -2782,8 +2703,7 @@ void MM_VerifyLoadDumpParams_Test_FillRAMValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillRAMValidateRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooSmall(void)
 {
@@ -2817,8 +2737,7 @@ void MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooLarge(void)
 {
@@ -2852,8 +2771,7 @@ void MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillEEPROMValidateRangeError(void)
 {
@@ -2890,8 +2808,7 @@ void MM_VerifyLoadDumpParams_Test_FillEEPROMValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillEEPROMValidateRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooSmall(void)
 {
@@ -2925,8 +2842,7 @@ void MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooLarge(void)
 {
@@ -2960,8 +2876,7 @@ void MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM32ValidateRangeError(void)
 {
@@ -2998,8 +2913,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32ValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM32ValidateRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooSmall(void)
 {
@@ -3033,8 +2947,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooLarge(void)
 {
@@ -3068,8 +2981,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM32AlignmentError(void)
 {
@@ -3103,8 +3015,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32AlignmentError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM32AlignmentError */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM16ValidateRangeError(void)
 {
@@ -3141,8 +3052,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16ValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM16ValidateRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooSmall(void)
 {
@@ -3176,8 +3086,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooLarge(void)
 {
@@ -3211,8 +3120,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM16AlignmentError(void)
 {
@@ -3246,8 +3154,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16AlignmentError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM16AlignmentError */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM8ValidateRangeError(void)
 {
@@ -3284,8 +3191,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM8ValidateRangeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM8ValidateRangeError */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooSmall(void)
 {
@@ -3319,8 +3225,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooLarge(void)
 {
@@ -3354,8 +3259,7 @@ void MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooLarge */
+}
 
 void MM_VerifyLoadDumpParams_Test_FillInvalidMemTypeError(void)
 {
@@ -3388,8 +3292,7 @@ void MM_VerifyLoadDumpParams_Test_FillInvalidMemTypeError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_FillMEM8InvalidMemTypeError */
+}
 
 /* WID */
 void MM_VerifyLoadDumpParams_Test_WIDNominal(void)
@@ -3411,8 +3314,7 @@ void MM_VerifyLoadDumpParams_Test_WIDNominal(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_WIDNominal */
+}
 
 void MM_VerifyLoadDumpParams_Test_WIDMemValidateError(void)
 {
@@ -3449,8 +3351,7 @@ void MM_VerifyLoadDumpParams_Test_WIDMemValidateError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_WIDMemValidateError */
+}
 
 void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooSmall(void)
 {
@@ -3484,8 +3385,7 @@ void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooSmall(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooSmall */
+}
 
 void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooLarge(void)
 {
@@ -3519,8 +3419,7 @@ void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooLarge(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
-
-} /* end MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooLarge */
+}
 
 void MM_Verify32Aligned_Test(void)
 {
@@ -3554,8 +3453,7 @@ void MM_Verify32Aligned_Test(void)
 
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");
-
-} /* end MM_Verify32Aligned_Test */
+}
 
 void MM_Verify16Aligned_Test(void)
 {
@@ -3589,8 +3487,7 @@ void MM_Verify16Aligned_Test(void)
 
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");
-
-} /* end MM_Verify16Aligned_Test */
+}
 
 void MM_ResolveSymAddr_Test(void)
 {
@@ -3893,9 +3790,4 @@ void UtTest_Setup(void)
     UtTest_Add(MM_ResolveSymAddr_Test, MM_Test_Setup, MM_Test_TearDown, "MM_ResolveSymAddr_Test");
 
     UtTest_Add(MM_ComputeCRCFromFile_Test, MM_Test_Setup, MM_Test_TearDown, "MM_ComputeCRCFromFile_Test");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #47
Removes redundant and inconsistent comments (e.g. `/* end of function */`, `/* end if */`, function name in function header comments).
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.

**Testing performed**
None (comment and whitespace changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 