### PR TITLE
Fix #50, Apply consistent Event ID names to common events

### DIFF
--- a/fsw/inc/mm_events.h
+++ b/fsw/inc/mm_events.h
@@ -228,7 +228,7 @@
  *  This event message is issued when a software bus message is received
  *  with an invalid command code.
  */
-#define MM_CC1_ERR_EID 17
+#define MM_CC_ERR_EID 17
 
 /**
  * \brief MM Command Message Length Invalid Event ID
@@ -240,7 +240,7 @@
  *  This event message is issued when command message is received with a message
  *  length that doesn't match the expected value.
  */
-#define MM_LEN_ERR_EID 18
+#define MM_CMD_LEN_ERR_EID 18
 
 /**
  * \brief MM Commanded Memory Type Invalid Event ID

--- a/fsw/inc/mm_msgdefs.h
+++ b/fsw/inc/mm_msgdefs.h
@@ -99,7 +99,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -131,7 +131,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -175,7 +175,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_DATA_SIZE_BITS_ERR_EID
  *       - Error specific event message #MM_MEMTYPE_ERR_EID
@@ -233,7 +233,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_DATA_SIZE_BITS_ERR_EID
  *       - Error specific event message #MM_MEMTYPE_ERR_EID
@@ -293,7 +293,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_LOAD_WID_CRC_ERR_EID
  *       - Error specific event message #MM_OS_MEMVALIDATE_ERR_EID
@@ -357,7 +357,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_OS_OPEN_ERR_EID
  *       - Error specific event message #MM_OS_CLOSE_ERR_EID
  *       - Error specific event message #MM_OS_READ_EXP_ERR_EID
@@ -430,7 +430,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_OS_CREAT_ERR_EID
  *       - Error specific event message #MM_CFE_FS_WRITEHDR_ERR_EID
@@ -488,7 +488,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_OS_MEMVALIDATE_ERR_EID
  *       - Error specific event message #MM_DATA_SIZE_BYTES_ERR_EID
@@ -542,7 +542,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_OS_MEMVALIDATE_ERR_EID
  *       - Error specific event message #MM_DATA_SIZE_BYTES_ERR_EID
@@ -592,7 +592,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_NUL_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *
@@ -630,7 +630,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_SYMFILENAME_NUL_ERR_EID
  *       - Error specific event message #MM_SYMTBL_TO_FILE_FAIL_ERR_EID
  *
@@ -668,7 +668,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_EEPROM_WRITE_ENA_ERR_EID
  *
  *  \par Criticality
@@ -706,7 +706,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #MM_HkPacket_Payload_t.ErrCounter will increment
- *       - Error specific event message #MM_LEN_ERR_EID
+ *       - Error specific event message #MM_CMD_LEN_ERR_EID
  *       - Error specific event message #MM_EEPROM_WRITE_DIS_ERR_EID
  *
  *  \par Criticality

--- a/fsw/src/mm_app.c
+++ b/fsw/src/mm_app.c
@@ -348,7 +348,7 @@ void MM_AppPipe(const CFE_SB_Buffer_t *BufPtr)
 
                 default:
                     CmdResult = false;
-                    CFE_EVS_SendEvent(MM_CC1_ERR_EID, CFE_EVS_EventType_ERROR,
+                    CFE_EVS_SendEvent(MM_CC_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "Invalid ground command code: ID = 0x%08lX, CC = %d",
                                       (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode);
                     break;

--- a/fsw/src/mm_utils.c
+++ b/fsw/src/mm_utils.c
@@ -117,7 +117,7 @@ bool MM_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
         }
         else
         {
-            CFE_EVS_SendEvent(MM_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(MM_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (int)ActualLength,
                               (int)ExpectedLength);

--- a/fsw/src/mm_utils.h
+++ b/fsw/src/mm_utils.h
@@ -79,7 +79,7 @@ void MM_SegmentBreak(void);
  *  \retval true  Length matches expected
  *  \retval false Length does not match expected
  *
- *  \sa #MM_LEN_ERR_EID
+ *  \sa #MM_CMD_LEN_ERR_EID
  */
 bool MM_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
 

--- a/unit-test/mm_app_tests.c
+++ b/unit-test/mm_app_tests.c
@@ -1100,7 +1100,7 @@ void MM_AppPipe_Test_InvalidCommandCode(void)
     UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
     UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_CC1_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_CC_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);

--- a/unit-test/mm_utils_tests.c
+++ b/unit-test/mm_utils_tests.c
@@ -180,7 +180,7 @@ void MM_VerifyCmdLength_Test_LengthError(void)
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #50 
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt