### PR TITLE
Fix #8, Remove unnecessary characters from memory dump event

### DIFF
--- a/fsw/src/mm_dump.c
+++ b/fsw/src/mm_dump.c
@@ -530,7 +530,7 @@ bool MM_DumpInEventCmd(const CFE_SB_Buffer_t *BufPtr)
                     BytePtr = (uint8 *)DumpBuffer;
                     for (i = 0; i < CmdPtr->NumOfBytes; i++)
                     {
-                        snprintf(TempString, MM_DUMPINEVENT_TEMP_CHARS, "0x%02X ", *BytePtr);
+                        snprintf(TempString, MM_DUMPINEVENT_TEMP_CHARS, "%02X ", *BytePtr);
                         CFE_SB_MessageStringGet(&EventString[EventStringTotalLength], TempString, NULL,
                                                 sizeof(EventString) - EventStringTotalLength, sizeof(TempString));
                         EventStringTotalLength = strlen(EventString);

--- a/fsw/src/mm_dump.h
+++ b/fsw/src/mm_dump.h
@@ -44,10 +44,10 @@
  *
  * The event message format is:
  *    Message head "Memory Dump: "             13 characters
- *    Message body "0xFF "                      5 characters per dump byte
+ *    Message body "FF"                         2 characters per dump byte
  *    Message tail "from address: 0xFFFFFFFF"  33 characters including NUL on 64-bit system
  */
-#define MM_MAX_DUMP_INEVENT_BYTES ((CFE_MISSION_EVS_MAX_MESSAGE_LENGTH - (13 + 33)) / 5)
+#define MM_MAX_DUMP_INEVENT_BYTES ((CFE_MISSION_EVS_MAX_MESSAGE_LENGTH - (13 + 33)) / 2)
 
 /**
  * \brief Dump in an event scratch string size


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #8
  - Removes the `0x` and trailing space around each byte from the dump event message.

**Testing performed**
Build & Run + Unit Tests.

**Expected behavior changes**
Increases the number of bytes that can be dumped in the event message string dramatically (by around double, depending on the value that is set for `CFE_MISSION_EVS_MAX_MESSAGE_LENGTH`).

**Contributor Info**
Avi Weiss @thnkslprpt