### PR TITLE
Fix #21, Add MM_SegmentBreak() to MM_FillMem()

### DIFF
--- a/fsw/inc/mm_events.h
+++ b/fsw/inc/mm_events.h
@@ -19,7 +19,7 @@
 
 /**
  * @file
- *   Specification for the CFS Memory Manger event identifers.
+ *   Specification for the CFS Memory Manger event identifiers.
  */
 #ifndef MM_EVENTS_H
 #define MM_EVENTS_H
@@ -560,7 +560,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when an symbol lookup command has been
+ *  This event message is issued when a symbol lookup command has been
  *  successfully executed.
  */
 #define MM_SYM_LOOKUP_INF_EID 45

--- a/fsw/src/mm_app.h
+++ b/fsw/src/mm_app.h
@@ -213,7 +213,7 @@ bool MM_SymTblToFileCmd(const CFE_SB_Buffer_t *msg);
  * \brief Write-enable EEPROM command
  *
  *  \par Description
- *       Processes a EEPROM write enable ground command which calls
+ *       Processes an EEPROM write enable ground command which calls
  *       the #CFE_PSP_EepromWriteEnable cFE function using the specified
  *       bank number.
  *
@@ -230,7 +230,7 @@ bool MM_EepromWriteEnaCmd(const CFE_SB_Buffer_t *msg);
  * \brief Write-disable EEPROM command
  *
  *  \par Description
- *       Processes a EEPROM write disable ground command which calls
+ *       Processes an EEPROM write disable ground command which calls
  *       the #CFE_PSP_EepromWriteDisable cFE function using the specified
  *       bank number.
  *

--- a/fsw/src/mm_load.c
+++ b/fsw/src/mm_load.c
@@ -829,6 +829,12 @@ bool MM_FillMem(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
         TargetPointer += SegmentSize;
         BytesProcessed += SegmentSize;
         BytesRemaining -= SegmentSize;
+
+        /* Prevent CPU hogging between load segments */
+        if (BytesRemaining != 0)
+        {
+            MM_SegmentBreak();
+        }
     }
 
     /* Stop EEPROM performance monitor */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #21 
  - Added call to `MM_SegmentBreak()` between segments in `MM_FillMem()`. 

**Testing performed**
CI Run + Build & Unit Tests still passing successfully.

**Expected behavior changes**
Removes this source of potential CPU hogging.

**Contributor Info**
Avi Weiss @thnkslprpt