### PR TITLE
Fix #54, Update initializations causing Cppcheck failure

### DIFF
--- a/fsw/src/mm_dump.c
+++ b/fsw/src/mm_dump.c
@@ -47,7 +47,7 @@ extern MM_AppData_t MM_AppData;
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_PeekCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    bool          Valid = true;
+    bool          Valid;
     MM_PeekCmd_t *CmdPtr;
     cpuaddr       SrcAddress     = 0;
     uint16        ExpectedLength = sizeof(MM_PeekCmd_t);
@@ -186,8 +186,8 @@ bool MM_PeekMem(const MM_PeekCmd_t *CmdPtr, cpuaddr SrcAddress)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_DumpMemToFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    bool                    Valid      = false;
-    int32                   OS_Status  = OS_SUCCESS;
+    bool                    Valid = false;
+    int32                   OS_Status;
     osal_id_t               FileHandle = OS_OBJECT_ID_UNDEFINED;
     cpuaddr                 SrcAddress = 0;
     MM_DumpMemToFileCmd_t * CmdPtr;
@@ -570,6 +570,7 @@ bool MM_FillDumpInEventBuffer(cpuaddr SrcAddress, const MM_DumpInEventCmd_t *Cmd
 #if defined(MM_OPT_CODE_MEM8_MEMTYPE) || defined(MM_OPT_CODE_MEM16_MEMTYPE) || defined(MM_OPT_CODE_MEM32_MEMTYPE)
     uint32 i;
 #endif
+    /* cppcheck-suppress unusedVariable */
     int32 PSP_Status;
     bool  Valid = true;
 

--- a/fsw/src/mm_load.c
+++ b/fsw/src/mm_load.c
@@ -293,7 +293,7 @@ bool MM_PokeEeprom(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
 bool MM_LoadMemWIDCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     MM_LoadMemWIDCmd_t *CmdPtr;
-    uint32              ComputedCRC    = 0;
+    uint32              ComputedCRC;
     cpuaddr             DestAddress    = 0;
     uint16              ExpectedLength = sizeof(MM_LoadMemWIDCmd_t);
     bool                CmdResult      = false;
@@ -361,9 +361,9 @@ bool MM_LoadMemWIDCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_LoadMemFromFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    bool                     Valid       = false;
-    osal_id_t                FileHandle  = OS_OBJECT_ID_UNDEFINED;
-    int32                    OS_Status   = OS_SUCCESS;
+    bool                     Valid      = false;
+    osal_id_t                FileHandle = OS_OBJECT_ID_UNDEFINED;
+    int32                    OS_Status;
     cpuaddr                  DestAddress = 0;
     MM_LoadMemFromFileCmd_t *CmdPtr;
     CFE_FS_Header_t          CFEFileHeader;

--- a/fsw/src/mm_mem16.c
+++ b/fsw/src/mm_mem16.c
@@ -51,8 +51,8 @@ extern MM_AppData_t MM_AppData;
 bool MM_LoadMem16FromFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader,
                           cpuaddr DestAddress)
 {
-    uint32  i              = 0;
-    int32   ReadLength     = 0;
+    uint32  i;
+    int32   ReadLength;
     int32   PSP_Status     = CFE_PSP_SUCCESS;
     int32   BytesProcessed = 0;
     int32   BytesRemaining = FileHeader->NumOfBytes;
@@ -134,10 +134,10 @@ bool MM_LoadMem16FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_DumpMem16ToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader)
 {
-    bool    Valid          = true;
-    int32   OS_Status      = OS_ERROR;
-    int32   PSP_Status     = CFE_PSP_SUCCESS;
-    uint32  i              = 0;
+    bool    Valid = true;
+    int32   OS_Status;
+    int32   PSP_Status = CFE_PSP_SUCCESS;
+    uint32  i;
     uint32  BytesProcessed = 0;
     uint32  BytesRemaining = FileHeader->NumOfBytes;
     uint16 *DataPointer16  = (uint16 *)(FileHeader->SymAddress.Offset);
@@ -220,15 +220,15 @@ bool MM_DumpMem16ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_FillMem16(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
 {
-    uint32  i                 = 0;
-    int32   PSP_Status        = CFE_PSP_SUCCESS;
-    uint32  BytesProcessed    = 0;
-    uint32  BytesRemaining    = CmdPtr->NumOfBytes;
-    uint32  NewBytesRemaining = 0;
-    uint16  FillPattern16     = (uint16)CmdPtr->FillPattern;
-    uint16 *DataPointer16     = (uint16 *)DestAddress;
-    uint32  SegmentSize       = MM_MAX_FILL_DATA_SEG;
-    bool    Result            = true;
+    uint32  i;
+    int32   PSP_Status     = CFE_PSP_SUCCESS;
+    uint32  BytesProcessed = 0;
+    uint32  BytesRemaining = CmdPtr->NumOfBytes;
+    uint32  NewBytesRemaining;
+    uint16  FillPattern16 = (uint16)CmdPtr->FillPattern;
+    uint16 *DataPointer16 = (uint16 *)DestAddress;
+    uint32  SegmentSize   = MM_MAX_FILL_DATA_SEG;
+    bool    Result        = true;
 
     /* Check fill size and warn if not a multiple of 2 */
     if ((BytesRemaining % 2) != 0)

--- a/fsw/src/mm_mem32.c
+++ b/fsw/src/mm_mem32.c
@@ -51,8 +51,8 @@ extern MM_AppData_t MM_AppData;
 bool MM_LoadMem32FromFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader,
                           cpuaddr DestAddress)
 {
-    uint32  i              = 0;
-    int32   ReadLength     = 0;
+    uint32  i;
+    int32   ReadLength;
     int32   PSP_Status     = CFE_PSP_SUCCESS;
     int32   BytesProcessed = 0;
     int32   BytesRemaining = FileHeader->NumOfBytes;
@@ -134,10 +134,10 @@ bool MM_LoadMem32FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_DumpMem32ToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader)
 {
-    bool    Valid          = true;
-    int32   OS_Status      = OS_ERROR;
-    int32   PSP_Status     = CFE_PSP_SUCCESS;
-    uint32  i              = 0;
+    bool    Valid = true;
+    int32   OS_Status;
+    int32   PSP_Status = CFE_PSP_SUCCESS;
+    uint32  i;
     uint32  BytesProcessed = 0;
     uint32  BytesRemaining = FileHeader->NumOfBytes;
     uint32 *DataPointer32  = (uint32 *)(FileHeader->SymAddress.Offset);
@@ -221,15 +221,15 @@ bool MM_DumpMem32ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_FillMem32(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
 {
-    uint32  i                 = 0;
-    int32   PSP_Status        = CFE_PSP_SUCCESS;
-    uint32  BytesProcessed    = 0;
-    uint32  BytesRemaining    = CmdPtr->NumOfBytes;
-    uint32  NewBytesRemaining = 0;
-    uint32  FillPattern32     = CmdPtr->FillPattern;
-    uint32 *DataPointer32     = (uint32 *)(DestAddress);
-    uint32  SegmentSize       = MM_MAX_FILL_DATA_SEG;
-    bool    Result            = true;
+    uint32  i;
+    int32   PSP_Status     = CFE_PSP_SUCCESS;
+    uint32  BytesProcessed = 0;
+    uint32  BytesRemaining = CmdPtr->NumOfBytes;
+    uint32  NewBytesRemaining;
+    uint32  FillPattern32 = CmdPtr->FillPattern;
+    uint32 *DataPointer32 = (uint32 *)(DestAddress);
+    uint32  SegmentSize   = MM_MAX_FILL_DATA_SEG;
+    bool    Result        = true;
 
     /* Check fill size and warn if not a multiple of 4 */
     if ((BytesRemaining % 4) != 0)

--- a/fsw/src/mm_mem8.c
+++ b/fsw/src/mm_mem8.c
@@ -51,8 +51,8 @@ extern MM_AppData_t MM_AppData;
 bool MM_LoadMem8FromFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader,
                          cpuaddr DestAddress)
 {
-    uint32 i              = 0;
-    int32  ReadLength     = 0;
+    uint32 i;
+    int32  ReadLength;
     int32  PSP_Status     = CFE_PSP_SUCCESS;
     int32  BytesProcessed = 0;
     int32  BytesRemaining = FileHeader->NumOfBytes;
@@ -134,10 +134,10 @@ bool MM_LoadMem8FromFile(osal_id_t FileHandle, const char *FileName, const MM_Lo
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_DumpMem8ToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader)
 {
-    bool   Valid          = true;
-    int32  OS_Status      = OS_ERROR;
-    int32  PSP_Status     = CFE_PSP_SUCCESS;
-    uint32 i              = 0;
+    bool   Valid = true;
+    int32  OS_Status;
+    int32  PSP_Status = CFE_PSP_SUCCESS;
+    uint32 i;
     uint32 BytesProcessed = 0;
     uint32 BytesRemaining = FileHeader->NumOfBytes;
     uint8 *DataPointer8   = (uint8 *)(FileHeader->SymAddress.Offset);
@@ -220,7 +220,7 @@ bool MM_DumpMem8ToFile(osal_id_t FileHandle, const char *FileName, const MM_Load
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_FillMem8(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
 {
-    uint32 i              = 0;
+    uint32 i;
     int32  PSP_Status     = CFE_PSP_SUCCESS;
     uint32 BytesProcessed = 0;
     uint32 BytesRemaining = CmdPtr->NumOfBytes;

--- a/fsw/src/mm_utils.c
+++ b/fsw/src/mm_utils.c
@@ -501,8 +501,8 @@ bool MM_Verify16Aligned(cpuaddr Address, uint32 Size)
 
 bool MM_ResolveSymAddr(MM_SymAddr_t *SymAddr, cpuaddr *ResolvedAddr)
 {
-    bool  Valid     = false;
-    int32 OS_Status = OS_SUCCESS;
+    bool  Valid = false;
+    int32 OS_Status;
 
     /*
     ** NUL terminate the very end of the symbol name string array as a


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #54
Note: all are local variables only.
In order of the errors reported in the issue report:

mm_dump.c
In the `MM_PeekCmd()` function:
`bool Valid = true;`: `Valid` is assigned a value (on line 62) before any and all of its references, so it can be safely changed from an initialization to a declaration-only at the top of the function.

In the `MM_DumpMemToFileCmd()` function:
`int32 OS_Status = OS_SUCCESS;`: `OS_Status` is assigned a value (on line 240) before any and all of its references (and all are covered logically by this assignment on line 240).

In the `MM_FillDumpInEventBuffer()` function:
`int32 PSP_Status;`: This is a false positive. I've added a `cppcheck-suppress` comment on the preceding line as part of this PR.

mm_load.c
In the `MM_LoadMemWIDCmd()` function:
`uint32 ComputedCRC = 0;`: `ComputedCRC` is only used on line 320 and it is assigned a value on the immediately preceding line of code.

In the `MM_LoadMemFromFileCmd()` function:
`int32 OS_Status = OS_SUCCESS;`: `OS_Status` is assigned a value on line 388 (and again on line 529) which cover logically all of its uses in the function.

mm_mem16.c
In the `MM_LoadMem16FromFile()` function:
`uint32 i = 0;`: `i` is assigned a value in the init-statement of the `for` loop on line 82, so the initialization at the top of the function is redundant.
`int32 ReadLength = 0;`: `ReadLength` is assigned a value in the `if` statement on line 72, and is only used once immediately after that inside that `if` block.

In the `MM_DumpMem16ToFile()` function:
`int32 OS_Status = OS_ERROR;`: `OS_Status` is assigned a value in the `if` statement on line 178, and is only used in that `if`/`else` block which is all covered by that local assignment on line 178. This makes the initialization at the top of the function redundant.
`uint32 i = 0;`: `i` is assigned a value in the init-statement of the `for` loop on line 155, so the initialization at the top of the function is redundant.

In the `MM_FillMem16()` function:
`uint32 i = 0;`: `i` is assigned a value in the init-statement of the `for` loop on line 252, so the initialization at the top of the function is redundant.
`uint32 NewBytesRemaining = 0;`: `NewBytesRemaining` is only used inside the `if` block (starting on line 234) and it is assigned a value there (on line 236) before any and all of its references.

mm_mem32.c
In the `MM_LoadMem32FromFile()` function:
`uint32 i = 0;`: `i` is assigned a value in the init-statement of the `for` loop on line 82, so the initialization at the top of the function is redundant.
`int32 ReadLength = 0;`: `ReadLength` is assigned a value in the `if` statement on line 72, and is only used once immediately after that inside that `if` block.

In the `MM_DumpMem32ToFile()` function:
`int32 OS_Status = OS_ERROR;`: `OS_Status` is assigned a value in the `if` statement on line 179, and is only used in that `if`/`else` block which is fully covered by that local assignment on line 179. This makes the initialization at the top of the function redundant.
`uint32 i = 0;`: `i` is assigned a value in the init-statement of the `for` loop on line 155, so the initialization at the top of the function is redundant.

In the `MM_FillMem32()` function:
`uint32 i = 0;`: `i` is assigned a value in the init-statement of the `for` loop on line 253, so the initialization at the top of the function is redundant.
`uint32 NewBytesRemaining = 0;`: `NewBytesRemaining` is only used inside the `if` block (starting on line 235) and it is assigned a value there (on line 237) before any and all of its references

mm_mem8.c
In the `MM_LoadMem8FromFile()` function:
`uint32 i = 0;`: `i` is assigned a value in the init-statement of the `for` loop on line 82, so the initialization at the top of the function is redundant.
`int32 ReadLength = 0;`: `ReadLength` is assigned a value in the `if` statement on line 72, and is only used once immediately after that inside that `if` block.

In the `MM_DumpMem8ToFile()` function:
`int32 OS_Status = OS_ERROR;`: `OS_Status` is assigned a value in the `if` statement on line 178, and is only used in that `if`/`else` block which is fully covered by that local assignment on line 178. This makes the initialization at the top of the function redundant.
`uint32 i = 0;`: `i` is assigned a value in the init-statement of the `for` loop on line 155, so the initialization at the top of the function is redundant.

In the `MM_FillMem8()` function:
`uint32 i = 0;`: `i` is assigned a value in the init-statement of the `for` loop on line 241, so the initialization at the top of the function is redundant.

mm_utils.c
`int32 OS_Status = OS_SUCCESS;`: `OS_Status` is assigned a value on line 528 and is only used once on the next line.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully if separate issue https://github.com/nasa/MM/issues/55 is suppressed
![image](https://user-images.githubusercontent.com/9024662/200222963-d0f9f7f0-0404-440f-b578-418c5c297bff.png)
The log from the successful build (with the GCC suppressions that can't be included in this PR) can be viewed here:
https://github.com/thnkslprpt/MM/actions/runs/3407355310/jobs/5667038143

**Expected behavior changes**
No impact on code behavior.
Cppcheck now passes without error again.

**Contributor Info**
Avi @thnkslprpt