### PR TITLE
Fix #59, 64-bit align cmd/tlm structures

### DIFF
--- a/fsw/src/mm_dump.c
+++ b/fsw/src/mm_dump.c
@@ -527,7 +527,7 @@ bool MM_DumpInEventCmd(const CFE_SB_Buffer_t *BufPtr)
                     for (i = 0; i < CmdPtr->NumOfBytes; i++)
                     {
                         snprintf(TempString, MM_DUMPINEVENT_TEMP_CHARS, "0x%02X ", *BytePtr);
-                        strncat(EventString, TempString, strlen(TempString));
+                        strncat(EventString, TempString, MM_DUMPINEVENT_TEMP_CHARS);
                         BytePtr++;
                     }
 
@@ -536,7 +536,7 @@ bool MM_DumpInEventCmd(const CFE_SB_Buffer_t *BufPtr)
                     ** This adds up to 33 characters depending on pointer representation including the NUL terminator
                     */
                     snprintf(TempString, MM_DUMPINEVENT_TEMP_CHARS, "from address: %p", (void *)SrcAddress);
-                    strncat(EventString, TempString, strlen(TempString));
+                    strncat(EventString, TempString, MM_DUMPINEVENT_TEMP_CHARS);
 
                     /* Send it out */
                     CFE_EVS_SendEvent(MM_DUMP_INEVENT_INF_EID, CFE_EVS_EventType_INFORMATION, "%s", EventString);

--- a/fsw/src/mm_msg.h
+++ b/fsw/src/mm_msg.h
@@ -88,8 +88,8 @@ typedef struct
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
     uint8        DataSize;      /**< \brief Size of the data to be read     */
+    uint8        Padding[3];    /**< \brief Structure padding               */
     MM_MemType_t MemType;       /**< \brief Memory type to peek data from   */
-    uint8        Padding[2];    /**< \brief Structure padding               */
     MM_SymAddr_t SrcSymAddress; /**< \brief Symbolic source peek address    */
 } MM_PeekCmd_t;
 
@@ -103,9 +103,10 @@ typedef struct
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
     uint8        DataSize;       /**< \brief Size of the data to be written     */
+    uint8        Padding1[3];    /**< \brief Structure padding                  */
     MM_MemType_t MemType;        /**< \brief Memory type to poke data to        */
-    uint8        Padding[2];     /**< \brief Structure padding                  */
     uint32       Data;           /**< \brief Data to be written                 */
+    uint8        Padding2[4];    /**< \brief Structure padding                  */
     MM_SymAddr_t DestSymAddress; /**< \brief Symbolic destination poke address  */
 } MM_PokeCmd_t;
 
@@ -136,7 +137,7 @@ typedef struct
 
     MM_MemType_t MemType;       /**< \brief Memory dump type             */
     uint8        NumOfBytes;    /**< \brief Number of bytes to be dumped */
-    uint16       Padding;       /**< \brief Structure padding            */
+    uint8        Padding[3];    /**< \brief Structure padding            */
     MM_SymAddr_t SrcSymAddress; /**< \brief Symbolic source address      */
 } MM_DumpInEventCmd_t;
 
@@ -162,7 +163,6 @@ typedef struct
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
     MM_MemType_t MemType;                   /**< \brief Memory dump type */
-    uint8        Padding[3];                /**< \brief Structure padding */
     uint32       NumOfBytes;                /**< \brief Number of bytes to be dumped */
     MM_SymAddr_t SrcSymAddress;             /**< \brief Symbol plus optional offset  */
     char         FileName[OS_MAX_PATH_LEN]; /**< \brief Name of memory dump file */
@@ -178,9 +178,9 @@ typedef struct
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
     MM_MemType_t MemType;        /**< \brief Memory type                  */
-    uint8        Padding[3];     /**< \brief Structure padding            */
     uint32       NumOfBytes;     /**< \brief Number of bytes to fill      */
     uint32       FillPattern;    /**< \brief Fill pattern to use          */
+    uint8        Padding[4];     /**< \brief Structure padding            */
     MM_SymAddr_t DestSymAddress; /**< \brief Symbol plus optional offset  */
 } MM_FillMemCmd_t;
 
@@ -249,6 +249,7 @@ typedef struct
     uint8        CmdCounter;                /**< \brief MM Application Command Counter */
     uint8        ErrCounter;                /**< \brief MM Application Command Error Counter */
     uint8        LastAction;                /**< \brief Last command action executed */
+    uint8        Padding;                   /**< \brief Last command action executed */
     MM_MemType_t MemType;                   /**< \brief Memory type for last command */
     cpuaddr      Address;                   /**< \brief Fully resolved address used for last command */
     uint32       DataValue;                 /**< \brief Last command data (fill pattern or peek/poke value) */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [ x] I reviewed the [Contributing Guide](https://github.com/nasa/MM/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds padding to cmd & tlm data structures for 64-bit alignment.

**Testing performed**
Updated ground database file(s) and ran build verification tests against both 32 & 64 bit systems.

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard
