### PR TITLE
Fix #67, Use `size_t` for 'size' variables

### DIFF
--- a/fsw/inc/mm_msg.h
+++ b/fsw/inc/mm_msg.h
@@ -87,8 +87,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    uint8        DataSize;      /**< \brief Size of the data to be read     */
-    uint8        Padding[3];    /**< \brief Structure padding               */
+    size_t       DataSize;      /**< \brief Size of the data to be read     */
     MM_MemType_t MemType;       /**< \brief Memory type to peek data from   */
     MM_SymAddr_t SrcSymAddress; /**< \brief Symbolic source peek address    */
 } MM_PeekCmd_t;
@@ -102,8 +101,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    uint8        DataSize;       /**< \brief Size of the data to be written     */
-    uint8        Padding1[3];    /**< \brief Structure padding                  */
+    size_t       DataSize;       /**< \brief Size of the data to be written     */
     MM_MemType_t MemType;        /**< \brief Memory type to poke data to        */
     uint32       Data;           /**< \brief Data to be written                 */
     uint8        Padding2[4];    /**< \brief Structure padding                  */
@@ -253,7 +251,7 @@ typedef struct
     MM_MemType_t MemType;                   /**< \brief Memory type for last command */
     cpuaddr      Address;                   /**< \brief Fully resolved address used for last command */
     uint32       DataValue;                 /**< \brief Last command data (fill pattern or peek/poke value) */
-    uint32       BytesProcessed;            /**< \brief Bytes processed for last command */
+    size_t       BytesProcessed;            /**< \brief Bytes processed for last command */
     char         FileName[OS_MAX_PATH_LEN]; /**< \brief Name of the data file used for last command, where applicable */
 } MM_HkPacket_t;
 

--- a/fsw/src/mm_dump.c
+++ b/fsw/src/mm_dump.c
@@ -50,7 +50,7 @@ bool MM_PeekCmd(const CFE_SB_Buffer_t *BufPtr)
     bool                Valid;
     const MM_PeekCmd_t *CmdPtr;
     cpuaddr             SrcAddress     = 0;
-    uint16              ExpectedLength = sizeof(MM_PeekCmd_t);
+    size_t              ExpectedLength = sizeof(MM_PeekCmd_t);
     bool                Result         = false;
     MM_SymAddr_t        SrcSymAddress;
 
@@ -103,9 +103,9 @@ bool MM_PeekMem(const MM_PeekCmd_t *CmdPtr, cpuaddr SrcAddress)
     uint16 WordValue      = 0;
     uint32 DWordValue     = 0;
     int32  PSP_Status     = 0;
-    uint32 BytesProcessed = 0;
+    size_t BytesProcessed = 0;
     uint32 DataValue      = 0;
-    uint8  DataSize       = 0;
+    size_t DataSize       = 0;
     uint32 EventID        = 0;
 
     /*
@@ -169,14 +169,14 @@ bool MM_PeekMem(const MM_PeekCmd_t *CmdPtr, cpuaddr SrcAddress)
         MM_AppData.HkPacket.DataValue      = DataValue;
 
         CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
-                          "Peek Command: Addr = %p Size = %d bits Data = 0x%08X", (void *)SrcAddress, DataSize,
-                          (unsigned int)DataValue);
+                          "Peek Command: Addr = %p Size = %u bits Data = 0x%08X", (void *)SrcAddress,
+                          (unsigned int)DataSize, (unsigned int)DataValue);
     }
     else
     {
         CFE_EVS_SendEvent(MM_PSP_READ_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "PSP read memory error: RC=%d, Address=%p, MemType=MEM%d", PSP_Status, (void *)SrcAddress,
-                          DataSize);
+                          "PSP read memory error: RC=%d, Address=%p, MemType=MEM%u", PSP_Status, (void *)SrcAddress,
+                          (unsigned int)DataSize);
     }
 
     return ValidPeek;
@@ -198,7 +198,7 @@ bool MM_DumpMemToFileCmd(const CFE_SB_Buffer_t *BufPtr)
     const MM_DumpMemToFileCmd_t *CmdPtr;
     CFE_FS_Header_t              CFEFileHeader;
     MM_LoadDumpFileHeader_t      MMFileHeader;
-    uint16                       ExpectedLength = sizeof(MM_DumpMemToFileCmd_t);
+    size_t                       ExpectedLength = sizeof(MM_DumpMemToFileCmd_t);
 
     /* Verify command packet length */
     if (MM_VerifyCmdLength(&BufPtr->Msg, ExpectedLength))
@@ -376,8 +376,8 @@ bool MM_DumpMemToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadD
     bool   ValidDump = false;
     int32  OS_Status;
     uint32 BytesRemaining = FileHeader->NumOfBytes;
-    uint32 BytesProcessed = 0;
-    uint32 SegmentSize    = MM_MAX_DUMP_DATA_SEG;
+    size_t BytesProcessed = 0;
+    size_t SegmentSize    = MM_MAX_DUMP_DATA_SEG;
     uint8 *SourcePtr      = (uint8 *)(FileHeader->SymAddress.Offset);
     uint8 *ioBuffer       = (uint8 *)&MM_AppData.DumpBuffer[0];
 
@@ -407,8 +407,8 @@ bool MM_DumpMemToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadD
         {
             BytesRemaining = 0;
             CFE_EVS_SendEvent(MM_OS_WRITE_EXP_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "OS_write error received: RC = %d, Expected = %d, File = '%s'", OS_Status,
-                              (int)SegmentSize, FileName);
+                              "OS_write error received: RC = %d, Expected = %u, File = '%s'", OS_Status,
+                              (unsigned int)SegmentSize, FileName);
         }
     }
 
@@ -461,8 +461,8 @@ bool MM_WriteFileHeaders(const char *FileName, osal_id_t FileHandle, CFE_FS_Head
             /* We either got an error or didn't read as much data as expected */
             Valid = false;
             CFE_EVS_SendEvent(MM_OS_WRITE_EXP_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "OS_write error received: RC = %d Expected = %d File = '%s'", OS_Status,
-                              (int)sizeof(MM_LoadDumpFileHeader_t), FileName);
+                              "OS_write error received: RC = %d Expected = %u File = '%s'", OS_Status,
+                              (unsigned int)sizeof(MM_LoadDumpFileHeader_t), FileName);
 
         } /* end OS_write if */
 
@@ -483,7 +483,7 @@ bool MM_DumpInEventCmd(const CFE_SB_Buffer_t *BufPtr)
     uint32                     i;
     int32                      EventStringTotalLength = 0;
     cpuaddr                    SrcAddress             = 0;
-    uint16                     ExpectedLength         = sizeof(MM_DumpInEventCmd_t);
+    size_t                     ExpectedLength         = sizeof(MM_DumpInEventCmd_t);
     uint8 *                    BytePtr;
     char                       TempString[MM_DUMPINEVENT_TEMP_CHARS];
     const char                 HeaderString[] = "Memory Dump: ";

--- a/fsw/src/mm_load.c
+++ b/fsw/src/mm_load.c
@@ -52,7 +52,7 @@ bool MM_PokeCmd(const CFE_SB_Buffer_t *BufPtr)
     bool                Valid       = false;
     cpuaddr             DestAddress = 0;
     const MM_PokeCmd_t *CmdPtr;
-    uint16              ExpectedLength = sizeof(MM_PokeCmd_t);
+    size_t              ExpectedLength = sizeof(MM_PokeCmd_t);
     MM_SymAddr_t        DestSymAddress;
 
     /* Verify command packet length */
@@ -112,9 +112,9 @@ bool MM_PokeMem(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
     uint16       WordValue;
     CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
     uint32       DataValue      = 0;
-    uint32       BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     bool         ValidPoke      = false;
-    uint8        DataSize       = 0; /* only used for giving MEM type/size in events */
+    size_t       DataSize       = 0; /* only used for giving MEM type/size in events */
     uint32       EventID        = 0;
 
     /* Write input number of bits to destination address */
@@ -173,14 +173,14 @@ bool MM_PokeMem(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
         MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
 
         CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
-                          "Poke Command: Addr = %p, Size = %d bits, Data = 0x%08X", (void *)DestAddress, DataSize,
-                          (unsigned int)DataValue);
+                          "Poke Command: Addr = %p, Size = %u bits, Data = 0x%08X", (void *)DestAddress,
+                          (unsigned int)DataSize, (unsigned int)DataValue);
     }
     else
     {
         CFE_EVS_SendEvent(MM_PSP_WRITE_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "PSP write memory error: RC=0x%08X, Address=%p, MemType=MEM%d", (unsigned int)PSP_Status,
-                          (void *)DestAddress, DataSize);
+                          "PSP write memory error: RC=0x%08X, Address=%p, MemType=MEM%u", (unsigned int)PSP_Status,
+                          (void *)DestAddress, (unsigned int)DataSize);
     }
 
     return ValidPoke;
@@ -197,7 +197,7 @@ bool MM_PokeEeprom(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
     uint16       WordValue;
     CFE_Status_t PSP_Status;
     uint32       DataValue      = 0;
-    uint32       BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     bool         ValidPoke      = false;
 
     CFE_ES_PerfLogEntry(MM_EEPROM_POKE_PERF_ID);
@@ -298,7 +298,7 @@ bool MM_LoadMemWIDCmd(const CFE_SB_Buffer_t *BufPtr)
     const MM_LoadMemWIDCmd_t *CmdPtr;
     uint32                    ComputedCRC;
     cpuaddr                   DestAddress    = 0;
-    uint16                    ExpectedLength = sizeof(MM_LoadMemWIDCmd_t);
+    size_t                    ExpectedLength = sizeof(MM_LoadMemWIDCmd_t);
     bool                      CmdResult      = false;
     MM_SymAddr_t              DestSymAddress;
 
@@ -376,7 +376,7 @@ bool MM_LoadMemFromFileCmd(const CFE_SB_Buffer_t *BufPtr)
     CFE_FS_Header_t                CFEFileHeader;
     MM_LoadDumpFileHeader_t        MMFileHeader;
     uint32                         ComputedCRC;
-    uint16                         ExpectedLength = sizeof(MM_LoadMemFromFileCmd_t);
+    size_t                         ExpectedLength = sizeof(MM_LoadMemFromFileCmd_t);
 
     memset(&MMFileHeader, 0, sizeof(MMFileHeader));
 
@@ -560,9 +560,9 @@ bool MM_LoadMemFromFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
 {
     bool   Valid          = false;
     int32  BytesRemaining = FileHeader->NumOfBytes;
-    int32  BytesProcessed = 0;
+    size_t BytesProcessed = 0;
     int32  ReadLength;
-    uint32 SegmentSize   = MM_MAX_LOAD_DATA_SEG;
+    size_t SegmentSize   = MM_MAX_LOAD_DATA_SEG;
     uint8 *ioBuffer      = (uint8 *)&MM_AppData.LoadBuffer[0];
     uint8 *TargetPointer = (uint8 *)DestAddress;
 
@@ -595,8 +595,8 @@ bool MM_LoadMemFromFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
         else
         {
             CFE_EVS_SendEvent(MM_OS_READ_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "OS_read error received: RC = 0x%08X Expected = %d File = '%s'", (unsigned int)ReadLength,
-                              (int)SegmentSize, FileName);
+                              "OS_read error received: RC = 0x%08X Expected = %u File = '%s'", (unsigned int)ReadLength,
+                              (unsigned int)SegmentSize, FileName);
             BytesRemaining = 0;
         }
     }
@@ -629,7 +629,7 @@ bool MM_VerifyLoadFileSize(const char *FileName, const MM_LoadDumpFileHeader_t *
 {
     bool       Valid = true;
     int32      OS_Status;
-    uint32     ExpectedSize;
+    size_t     ExpectedSize;
     int32      ActualSize; /* The size returned by OS_stat is signed */
     os_fstat_t FileStats;
 
@@ -663,8 +663,8 @@ bool MM_VerifyLoadFileSize(const char *FileName, const MM_LoadDumpFileHeader_t *
             ** the variable ActualSize to this function.
             */
             CFE_EVS_SendEvent(MM_LD_FILE_SIZE_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Load file size error: Reported by OS = %d Expected = %d File = '%s'", (int)ActualSize,
-                              (int)ExpectedSize, FileName);
+                              "Load file size error: Reported by OS = %d Expected = %u File = '%s'", (int)ActualSize,
+                              (unsigned int)ExpectedSize, FileName);
         }
     }
 
@@ -725,7 +725,7 @@ bool MM_FillMemCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     cpuaddr                DestAddress    = 0;
     const MM_FillMemCmd_t *CmdPtr         = (MM_FillMemCmd_t *)BufPtr;
-    uint16                 ExpectedLength = sizeof(MM_FillMemCmd_t);
+    size_t                 ExpectedLength = sizeof(MM_FillMemCmd_t);
     bool                   CmdResult      = false;
     MM_SymAddr_t           DestSymAddress = CmdPtr->DestSymAddress;
 
@@ -800,7 +800,7 @@ bool MM_FillMem(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
 {
     uint16 i;
     bool   Valid          = true;
-    uint32 BytesProcessed = 0;
+    size_t BytesProcessed = 0;
     uint32 BytesRemaining = CmdPtr->NumOfBytes;
     uint32 SegmentSize    = MM_MAX_FILL_DATA_SEG;
     uint8 *TargetPointer  = (uint8 *)DestAddress;

--- a/fsw/src/mm_mem16.c
+++ b/fsw/src/mm_mem16.c
@@ -54,11 +54,11 @@ bool MM_LoadMem16FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
     uint32       i;
     int32        ReadLength;
     CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
-    int32        BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     int32        BytesRemaining = FileHeader->NumOfBytes;
     uint16 *     DataPointer16  = (uint16 *)DestAddress;
     uint16 *     ioBuffer16     = (uint16 *)&MM_AppData.LoadBuffer[0];
-    uint32       SegmentSize    = MM_MAX_LOAD_DATA_SEG;
+    size_t       SegmentSize    = MM_MAX_LOAD_DATA_SEG;
     bool         Valid          = false;
 
     while (BytesRemaining != 0)
@@ -73,8 +73,8 @@ bool MM_LoadMem16FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
         {
             BytesRemaining = 0;
             CFE_EVS_SendEvent(MM_OS_READ_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "OS_read error received: RC = 0x%08X Expected = %d File = '%s'", (unsigned int)ReadLength,
-                              (int)SegmentSize, FileName);
+                              "OS_read error received: RC = 0x%08X Expected = %u File = '%s'", (unsigned int)ReadLength,
+                              (unsigned int)SegmentSize, FileName);
         }
         else
         {
@@ -138,11 +138,11 @@ bool MM_DumpMem16ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
     int32        OS_Status;
     CFE_Status_t PSP_Status = CFE_PSP_SUCCESS;
     uint32       i;
-    uint32       BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     uint32       BytesRemaining = FileHeader->NumOfBytes;
     uint16 *     DataPointer16  = (uint16 *)(FileHeader->SymAddress.Offset);
     uint16 *     ioBuffer16     = (uint16 *)&MM_AppData.DumpBuffer[0];
-    uint32       SegmentSize    = MM_MAX_DUMP_DATA_SEG;
+    size_t       SegmentSize    = MM_MAX_DUMP_DATA_SEG;
 
     while (BytesRemaining != 0)
     {
@@ -193,8 +193,8 @@ bool MM_DumpMem16ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
                 Valid          = false;
                 BytesRemaining = 0;
                 CFE_EVS_SendEvent(MM_OS_WRITE_EXP_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "OS_write error received: RC = 0x%08X Expected = %d File = '%s'",
-                                  (unsigned int)OS_Status, (int)SegmentSize, FileName);
+                                  "OS_write error received: RC = 0x%08X Expected = %u File = '%s'",
+                                  (unsigned int)OS_Status, (unsigned int)SegmentSize, FileName);
             }
         }
     }
@@ -222,12 +222,12 @@ bool MM_FillMem16(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
 {
     uint32       i;
     CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
-    uint32       BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     uint32       BytesRemaining = CmdPtr->NumOfBytes;
     uint32       NewBytesRemaining;
     uint16       FillPattern16 = (uint16)CmdPtr->FillPattern;
     uint16 *     DataPointer16 = (uint16 *)DestAddress;
-    uint32       SegmentSize   = MM_MAX_FILL_DATA_SEG;
+    size_t       SegmentSize   = MM_MAX_FILL_DATA_SEG;
     bool         Result        = true;
 
     /* Check fill size and warn if not a multiple of 2 */

--- a/fsw/src/mm_mem32.c
+++ b/fsw/src/mm_mem32.c
@@ -54,11 +54,11 @@ bool MM_LoadMem32FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
     uint32       i;
     int32        ReadLength;
     CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
-    int32        BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     int32        BytesRemaining = FileHeader->NumOfBytes;
     uint32 *     DataPointer32  = (uint32 *)DestAddress;
     uint32 *     ioBuffer32     = (uint32 *)&MM_AppData.LoadBuffer[0];
-    uint32       SegmentSize    = MM_MAX_LOAD_DATA_SEG;
+    size_t       SegmentSize    = MM_MAX_LOAD_DATA_SEG;
     bool         Valid          = false;
 
     while (BytesRemaining != 0)
@@ -73,8 +73,8 @@ bool MM_LoadMem32FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
         {
             BytesRemaining = 0;
             CFE_EVS_SendEvent(MM_OS_READ_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "OS_read error received: RC = 0x%08X Expected = %d File = '%s'", (unsigned int)ReadLength,
-                              (int)SegmentSize, FileName);
+                              "OS_read error received: RC = 0x%08X Expected = %u File = '%s'", (unsigned int)ReadLength,
+                              (unsigned int)SegmentSize, FileName);
         }
         else
         {
@@ -138,11 +138,11 @@ bool MM_DumpMem32ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
     int32        OS_Status;
     CFE_Status_t PSP_Status = CFE_PSP_SUCCESS;
     uint32       i;
-    uint32       BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     uint32       BytesRemaining = FileHeader->NumOfBytes;
     uint32 *     DataPointer32  = (uint32 *)(FileHeader->SymAddress.Offset);
     uint32 *     ioBuffer32     = (uint32 *)&MM_AppData.DumpBuffer[0];
-    uint32       SegmentSize    = MM_MAX_DUMP_DATA_SEG;
+    size_t       SegmentSize    = MM_MAX_DUMP_DATA_SEG;
 
     while (BytesRemaining != 0)
     {
@@ -194,8 +194,8 @@ bool MM_DumpMem32ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
                 Valid          = false;
                 BytesRemaining = 0;
                 CFE_EVS_SendEvent(MM_OS_WRITE_EXP_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "OS_write error received: RC = 0x%08X Expected = %d File = '%s'",
-                                  (unsigned int)OS_Status, (int)SegmentSize, FileName);
+                                  "OS_write error received: RC = 0x%08X Expected = %u File = '%s'",
+                                  (unsigned int)OS_Status, (unsigned int)SegmentSize, FileName);
             }
         }
     }
@@ -223,12 +223,12 @@ bool MM_FillMem32(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
 {
     uint32       i;
     CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
-    uint32       BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     uint32       BytesRemaining = CmdPtr->NumOfBytes;
     uint32       NewBytesRemaining;
     uint32       FillPattern32 = CmdPtr->FillPattern;
     uint32 *     DataPointer32 = (uint32 *)(DestAddress);
-    uint32       SegmentSize   = MM_MAX_FILL_DATA_SEG;
+    size_t       SegmentSize   = MM_MAX_FILL_DATA_SEG;
     bool         Result        = true;
 
     /* Check fill size and warn if not a multiple of 4 */

--- a/fsw/src/mm_mem8.c
+++ b/fsw/src/mm_mem8.c
@@ -54,11 +54,11 @@ bool MM_LoadMem8FromFile(osal_id_t FileHandle, const char *FileName, const MM_Lo
     uint32       i;
     int32        ReadLength;
     CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
-    int32        BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     int32        BytesRemaining = FileHeader->NumOfBytes;
     uint8 *      DataPointer8   = (uint8 *)DestAddress;
     uint8 *      ioBuffer8      = (uint8 *)&MM_AppData.LoadBuffer[0];
-    uint32       SegmentSize    = MM_MAX_LOAD_DATA_SEG;
+    size_t       SegmentSize    = MM_MAX_LOAD_DATA_SEG;
     bool         Valid          = false;
 
     while (BytesRemaining != 0)
@@ -73,8 +73,8 @@ bool MM_LoadMem8FromFile(osal_id_t FileHandle, const char *FileName, const MM_Lo
         {
             BytesRemaining = 0;
             CFE_EVS_SendEvent(MM_OS_READ_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "OS_read error received: RC = 0x%08X Expected = %d File = '%s'", (unsigned int)ReadLength,
-                              (int)SegmentSize, FileName);
+                              "OS_read error received: RC = 0x%08X Expected = %u File = '%s'", (unsigned int)ReadLength,
+                              (unsigned int)SegmentSize, FileName);
         }
         else
         {
@@ -138,11 +138,11 @@ bool MM_DumpMem8ToFile(osal_id_t FileHandle, const char *FileName, const MM_Load
     int32        OS_Status;
     CFE_Status_t PSP_Status = CFE_PSP_SUCCESS;
     uint32       i;
-    uint32       BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     uint32       BytesRemaining = FileHeader->NumOfBytes;
     uint8 *      DataPointer8   = (uint8 *)(FileHeader->SymAddress.Offset);
     uint8 *      ioBuffer8      = (uint8 *)&MM_AppData.DumpBuffer[0];
-    uint32       SegmentSize    = MM_MAX_DUMP_DATA_SEG;
+    size_t       SegmentSize    = MM_MAX_DUMP_DATA_SEG;
 
     while (BytesRemaining != 0)
     {
@@ -193,8 +193,8 @@ bool MM_DumpMem8ToFile(osal_id_t FileHandle, const char *FileName, const MM_Load
                 Valid          = false;
                 BytesRemaining = 0;
                 CFE_EVS_SendEvent(MM_OS_WRITE_EXP_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "OS_write error received: RC = 0x%08X Expected = %d File = '%s'",
-                                  (unsigned int)OS_Status, (int)SegmentSize, FileName);
+                                  "OS_write error received: RC = 0x%08X Expected = %u File = '%s'",
+                                  (unsigned int)OS_Status, (unsigned int)SegmentSize, FileName);
             }
         }
     }
@@ -222,11 +222,11 @@ bool MM_FillMem8(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
 {
     uint32       i;
     CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
-    uint32       BytesProcessed = 0;
+    size_t       BytesProcessed = 0;
     uint32       BytesRemaining = CmdPtr->NumOfBytes;
     uint8        FillPattern8   = (uint8)CmdPtr->FillPattern;
     uint8 *      DataPointer8   = (uint8 *)DestAddress;
-    uint32       SegmentSize    = MM_MAX_FILL_DATA_SEG;
+    size_t       SegmentSize    = MM_MAX_FILL_DATA_SEG;
     bool         Result         = true;
 
     while (BytesRemaining != 0)

--- a/fsw/src/mm_utils.c
+++ b/fsw/src/mm_utils.c
@@ -134,11 +134,11 @@ bool MM_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 /* Verify peek and poke command parameters                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeInBits)
+bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, size_t SizeInBits)
 {
-    bool  Valid = true;
-    uint8 SizeInBytes;
-    int32 OS_Status;
+    bool   Valid = true;
+    size_t SizeInBytes;
+    int32  OS_Status;
 
     switch (SizeInBits)
     {
@@ -152,8 +152,8 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
             {
                 Valid = false;
                 CFE_EVS_SendEvent(MM_ALIGN16_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Data and address not 16 bit aligned: Addr = %p Size = %d", (void *)Address,
-                                  SizeInBytes);
+                                  "Data and address not 16 bit aligned: Addr = %p Size = %u", (void *)Address,
+                                  (unsigned int)SizeInBytes);
             }
             break;
 
@@ -163,15 +163,15 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
             {
                 Valid = false;
                 CFE_EVS_SendEvent(MM_ALIGN32_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Data and address not 32 bit aligned: Addr = %p Size = %d", (void *)Address,
-                                  SizeInBytes);
+                                  "Data and address not 32 bit aligned: Addr = %p Size = %u", (void *)Address,
+                                  (unsigned int)SizeInBytes);
             }
             break;
 
         default:
             Valid = false;
             CFE_EVS_SendEvent(MM_DATA_SIZE_BITS_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Data size in bits invalid: Data Size = %d", SizeInBits);
+                              "Data size in bits invalid: Data Size = %u", (unsigned int)SizeInBits);
             break;
     }
 
@@ -187,9 +187,9 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d "
+                                      "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %u "
                                       "MemType = MEM_RAM",
-                                      (unsigned int)OS_Status, (void *)Address, SizeInBytes);
+                                      (unsigned int)OS_Status, (void *)Address, (unsigned int)SizeInBytes);
                 }
                 break;
 
@@ -200,9 +200,9 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d "
+                                      "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %u "
                                       "MemType = MEM_EEPROM",
-                                      (unsigned int)OS_Status, (void *)Address, SizeInBytes);
+                                      (unsigned int)OS_Status, (void *)Address, (unsigned int)SizeInBytes);
                 }
                 break;
 
@@ -215,8 +215,8 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
                     Valid = false;
                     CFE_EVS_SendEvent(
                         MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d MemType = MEM32",
-                        (unsigned int)OS_Status, (void *)Address, SizeInBytes);
+                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %u MemType = MEM32",
+                        (unsigned int)OS_Status, (void *)Address, (unsigned int)SizeInBytes);
                 }
                 /*
                 ** Peeks and Pokes must be 32 bits wide for this memory type
@@ -225,7 +225,7 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_DATA_SIZE_BITS_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "Data size in bits invalid: Data Size = %d", SizeInBits);
+                                      "Data size in bits invalid: Data Size = %u", (unsigned int)SizeInBits);
                 }
                 break;
 #endif /* MM_OPT_CODE_MEM32_MEMTYPE */
@@ -239,8 +239,8 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
                     Valid = false;
                     CFE_EVS_SendEvent(
                         MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d MemType = MEM16",
-                        (unsigned int)OS_Status, (void *)Address, SizeInBytes);
+                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %u MemType = MEM16",
+                        (unsigned int)OS_Status, (void *)Address, (unsigned int)SizeInBytes);
                 }
                 /*
                 ** Peeks and Pokes must be 16 bits wide for this memory type
@@ -249,7 +249,7 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_DATA_SIZE_BITS_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "Data size in bits invalid: Data Size = %d", SizeInBits);
+                                      "Data size in bits invalid: Data Size = %u", (unsigned int)SizeInBits);
                 }
                 break;
 #endif /* MM_OPT_CODE_MEM16_MEMTYPE */
@@ -263,8 +263,8 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
                     Valid = false;
                     CFE_EVS_SendEvent(
                         MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d MemType = MEM8",
-                        (unsigned int)OS_Status, (void *)Address, SizeInBytes);
+                        "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %u MemType = MEM8",
+                        (unsigned int)OS_Status, (void *)Address, (unsigned int)SizeInBytes);
                 }
                 /*
                 ** Peeks and Pokes must be 8 bits wide for this memory type
@@ -273,7 +273,7 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_DATA_SIZE_BITS_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "Data size in bits invalid: Data Size = %d", SizeInBits);
+                                      "Data size in bits invalid: Data Size = %u", (unsigned int)SizeInBits);
                 }
                 break;
 #endif /* MM_OPT_CODE_MEM8_MEMTYPE */
@@ -296,11 +296,11 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
 /* Verify load/dump memory parameters                              */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeInBytes, uint8 VerifyType)
+bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, size_t SizeInBytes, uint8 VerifyType)
 {
     bool         Valid = true;
     CFE_Status_t PSP_Status;
-    uint32       MaxSize     = 0;
+    size_t       MaxSize     = 0;
     uint32       PSP_MemType = 0;
     char         MemTypeStr[MM_MAX_MEM_TYPE_STR_LEN];
 
@@ -386,8 +386,8 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeI
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_ALIGN32_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "Data and address not 32 bit aligned: Addr = %p Size = %d", (void *)Address,
-                                      (int)SizeInBytes);
+                                      "Data and address not 32 bit aligned: Addr = %p Size = %u", (void *)Address,
+                                      (unsigned int)SizeInBytes);
                 }
                 break;
 #endif
@@ -411,8 +411,8 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeI
                 {
                     Valid = false;
                     CFE_EVS_SendEvent(MM_ALIGN16_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "Data and address not 16 bit aligned: Addr = %p Size = %d", (void *)Address,
-                                      (int)SizeInBytes);
+                                      "Data and address not 16 bit aligned: Addr = %p Size = %u", (void *)Address,
+                                      (unsigned int)SizeInBytes);
                 }
                 break;
 #endif
@@ -449,7 +449,8 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeI
         {
             Valid = false;
             CFE_EVS_SendEvent(MM_DATA_SIZE_BYTES_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Data size in bytes invalid or exceeds limits: Data Size = %d", (int)SizeInBytes);
+                              "Data size in bytes invalid or exceeds limits: Data Size = %u",
+                              (unsigned int)SizeInBytes);
         }
     }
 
@@ -461,8 +462,8 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeI
         {
             Valid = false;
             CFE_EVS_SendEvent(MM_OS_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %d MemType = %s",
-                              (unsigned int)PSP_Status, (void *)Address, (int)SizeInBytes, MemTypeStr);
+                              "CFE_PSP_MemValidateRange error received: RC = 0x%08X Addr = %p Size = %u MemType = %s",
+                              (unsigned int)PSP_Status, (void *)Address, (unsigned int)SizeInBytes, MemTypeStr);
         }
     }
 
@@ -471,7 +472,7 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeI
 
 /******************************************************************************/
 
-bool MM_Verify32Aligned(cpuaddr Address, uint32 Size)
+bool MM_Verify32Aligned(cpuaddr Address, size_t Size)
 {
     bool IsAligned = false;
 
@@ -485,7 +486,7 @@ bool MM_Verify32Aligned(cpuaddr Address, uint32 Size)
 
 /******************************************************************************/
 
-bool MM_Verify16Aligned(cpuaddr Address, uint32 Size)
+bool MM_Verify16Aligned(cpuaddr Address, size_t Size)
 {
     bool IsAligned = false;
 

--- a/fsw/src/mm_utils.h
+++ b/fsw/src/mm_utils.h
@@ -105,7 +105,7 @@ bool MM_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
  *  \retval true  Validation passed
  *  \retval false Validation failed
  */
-bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeInBits);
+bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, size_t SizeInBits);
 
 /**
  * \brief Verify memory load and dump parameters
@@ -130,7 +130,7 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
  *  \retval true  Validation passed
  *  \retval false Validation failed
  */
-bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeInBytes, uint8 VerifyType);
+bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, size_t SizeInBytes, uint8 VerifyType);
 
 /**
  * \brief Verify 32 bit alignment
@@ -153,7 +153,7 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeI
  *
  *  \sa #MM_Verify16Aligned
  */
-bool MM_Verify32Aligned(cpuaddr Address, uint32 Size);
+bool MM_Verify32Aligned(cpuaddr Address, size_t Size);
 
 /**
  * \brief Verify 16 bit alignment
@@ -175,7 +175,7 @@ bool MM_Verify32Aligned(cpuaddr Address, uint32 Size);
  *
  *  \sa #MM_Verify32Aligned
  */
-bool MM_Verify16Aligned(cpuaddr Address, uint32 Size);
+bool MM_Verify16Aligned(cpuaddr Address, size_t Size);
 
 /**
  * \brief Resolve symbolic address

--- a/unit-test/mm_dump_tests.c
+++ b/unit-test/mm_dump_tests.c
@@ -89,7 +89,7 @@ void MM_PeekCmd_Test_Nominal(void)
     bool              Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Peek Command: Addr = %%p Size = %%d bits Data = 0x%%08X");
+             "Peek Command: Addr = %%p Size = %%u bits Data = 0x%%08X");
 
     UT_CmdBuf.PeekCmd.MemType  = MM_RAM;
     UT_CmdBuf.PeekCmd.DataSize = 32;
@@ -224,7 +224,7 @@ void MM_PeekMem_Test_Byte(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Peek Command: Addr = %%p Size = %%d bits Data = 0x%%08X");
+             "Peek Command: Addr = %%p Size = %%u bits Data = 0x%%08X");
 
     CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
     CmdPacket.MemType  = MM_RAM;
@@ -267,7 +267,7 @@ void MM_PeekMem_Test_ByteError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "PSP read memory error: RC=%%d, Address=%%p, MemType=MEM%%d");
+             "PSP read memory error: RC=%%d, Address=%%p, MemType=MEM%%u");
 
     CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
 
@@ -305,7 +305,7 @@ void MM_PeekMem_Test_Word(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Peek Command: Addr = %%p Size = %%d bits Data = 0x%%08X");
+             "Peek Command: Addr = %%p Size = %%u bits Data = 0x%%08X");
 
     CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
     CmdPacket.MemType  = MM_RAM;
@@ -348,7 +348,7 @@ void MM_PeekMem_Test_WordError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "PSP read memory error: RC=%%d, Address=%%p, MemType=MEM%%d");
+             "PSP read memory error: RC=%%d, Address=%%p, MemType=MEM%%u");
 
     CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
 
@@ -387,7 +387,7 @@ void MM_PeekMem_Test_DWord(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Peek Command: Addr = %%p Size = %%d bits Data = 0x%%08X");
+             "Peek Command: Addr = %%p Size = %%u bits Data = 0x%%08X");
 
     CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
     CmdPacket.MemType  = MM_RAM;
@@ -430,7 +430,7 @@ void MM_PeekMem_Test_DWordError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "PSP read memory error: RC=%%d, Address=%%p, MemType=MEM%%d");
+             "PSP read memory error: RC=%%d, Address=%%p, MemType=MEM%%u");
 
     CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
 
@@ -1543,7 +1543,7 @@ void MM_DumpMemToFile_Test_WriteError(void)
     bool                    Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "OS_write error received: RC = %%d, Expected = %%d, File = '%%s'");
+             "OS_write error received: RC = %%d, Expected = %%u, File = '%%s'");
 
     strncpy(FileName, "filename", sizeof(FileName) - 1);
     FileName[sizeof(FileName) - 1] = '\0';
@@ -1669,7 +1669,7 @@ void MM_WriteFileHeaders_Test_WriteError(void)
     bool                    Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "OS_write error received: RC = %%d Expected = %%d File = '%%s'");
+             "OS_write error received: RC = %%d Expected = %%u File = '%%s'");
 
     strncpy(FileName, "filename", sizeof(FileName) - 1);
     FileName[sizeof(FileName) - 1] = '\0';

--- a/unit-test/mm_load_tests.c
+++ b/unit-test/mm_load_tests.c
@@ -255,7 +255,7 @@ void MM_PokeCmd_Test_NonEEPROM(void)
     bool              Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = %%p, Size = %%d bits, Data = 0x%%08X");
+             "Poke Command: Addr = %%p, Size = %%u bits, Data = 0x%%08X");
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_POKE_CC;
@@ -429,7 +429,7 @@ void MM_PokeMem_Test_8bit(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = %%p, Size = %%d bits, Data = 0x%%08X");
+             "Poke Command: Addr = %%p, Size = %%u bits, Data = 0x%%08X");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
@@ -475,7 +475,7 @@ void MM_PokeMem_Test_8bitError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%d");
+             "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%u");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
@@ -519,7 +519,7 @@ void MM_PokeMem_Test_16bit(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = %%p, Size = %%d bits, Data = 0x%%08X");
+             "Poke Command: Addr = %%p, Size = %%u bits, Data = 0x%%08X");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
@@ -565,7 +565,7 @@ void MM_PokeMem_Test_16bitError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%d");
+             "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%u");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
@@ -609,7 +609,7 @@ void MM_PokeMem_Test_32bit(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Poke Command: Addr = %%p, Size = %%d bits, Data = 0x%%08X");
+             "Poke Command: Addr = %%p, Size = %%u bits, Data = 0x%%08X");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
@@ -655,7 +655,7 @@ void MM_PokeMem_Test_32bitError(void)
     bool         Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%d");
+             "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%u");
 
     CmdPacket.MemType  = MM_RAM;
     CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
@@ -1664,7 +1664,7 @@ void MM_LoadMemFromFileCmd_Test_NoVerifyLoadFileSize(void)
     bool  Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Load file size error: Reported by OS = %%d Expected = %%d File = '%%s'");
+             "Load file size error: Reported by OS = %%d Expected = %%u File = '%%s'");
 
     strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
 
@@ -2136,7 +2136,7 @@ void MM_LoadMemFromFile_Test_ReadError(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "OS_read error received: RC = 0x%%08X Expected = %%d File = '%%s'");
+             "OS_read error received: RC = 0x%%08X Expected = %%u File = '%%s'");
 
     /* Set to generate error message MM_OS_READ_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(OS_read), 1, 0);
@@ -2315,7 +2315,7 @@ void MM_VerifyLoadFileSize_Test_SizeError(void)
     char                    ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Load file size error: Reported by OS = %%d Expected = %%d File = '%%s'");
+             "Load file size error: Reported by OS = %%d Expected = %%u File = '%%s'");
 
     FileHeader.NumOfBytes = 99;
 

--- a/unit-test/mm_mem16_tests.c
+++ b/unit-test/mm_mem16_tests.c
@@ -135,7 +135,7 @@ void MM_LoadMem16FromFile_Test_ReadError(void)
     char                    ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "OS_read error received: RC = 0x%%08X Expected = %%d File = '%%s'");
+             "OS_read error received: RC = 0x%%08X Expected = %%u File = '%%s'");
 
     FileHeader.NumOfBytes = 2;
 
@@ -333,7 +333,7 @@ void MM_DumpMem16ToFile_Test_WriteError(void)
     memset(&FileHeader, 0, sizeof(FileHeader));
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "OS_write error received: RC = 0x%%08X Expected = %%d File = '%%s'");
+             "OS_write error received: RC = 0x%%08X Expected = %%u File = '%%s'");
 
     FileHeader.NumOfBytes = 2;
 

--- a/unit-test/mm_mem32_tests.c
+++ b/unit-test/mm_mem32_tests.c
@@ -135,7 +135,7 @@ void MM_LoadMem32FromFile_Test_ReadError(void)
     char                    ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "OS_read error received: RC = 0x%%08X Expected = %%d File = '%%s'");
+             "OS_read error received: RC = 0x%%08X Expected = %%u File = '%%s'");
 
     FileHeader.NumOfBytes = 4;
 
@@ -335,7 +335,7 @@ void MM_DumpMem32ToFile_Test_WriteError(void)
     memset(&FileHeader, 0, sizeof(FileHeader));
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "OS_write error received: RC = 0x%%08X Expected = %%d File = '%%s'");
+             "OS_write error received: RC = 0x%%08X Expected = %%u File = '%%s'");
 
     FileHeader.NumOfBytes = 4;
 

--- a/unit-test/mm_mem8_tests.c
+++ b/unit-test/mm_mem8_tests.c
@@ -135,7 +135,7 @@ void MM_LoadMem8FromFile_Test_ReadError(void)
     char                    ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "OS_read error received: RC = 0x%%08X Expected = %%d File = '%%s'");
+             "OS_read error received: RC = 0x%%08X Expected = %%u File = '%%s'");
 
     FileHeader.NumOfBytes = 2;
 
@@ -335,7 +335,7 @@ void MM_DumpMem8ToFile_Test_WriteError(void)
     memset(&FileHeader, 0, sizeof(FileHeader));
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "OS_write error received: RC = 0x%%08X Expected = %%d File = '%%s'");
+             "OS_write error received: RC = 0x%%08X Expected = %%u File = '%%s'");
 
     FileHeader.NumOfBytes = 2;
 

--- a/unit-test/mm_utils_tests.c
+++ b/unit-test/mm_utils_tests.c
@@ -89,7 +89,7 @@ void MM_ResetHk_Test(void)
 void MM_VerifyCmdLength_Test_Nominal(void)
 {
     bool              Result;
-    uint16            ExpectedLength = sizeof(MM_PeekCmd_t);
+    size_t            ExpectedLength = sizeof(MM_PeekCmd_t);
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
     size_t            MsgSize;
@@ -120,7 +120,7 @@ void MM_VerifyCmdLength_Test_Nominal(void)
 void MM_VerifyCmdLength_Test_HKRequestLengthError(void)
 {
     bool              Result;
-    uint16            ExpectedLength = 99;
+    size_t            ExpectedLength = 99;
     CFE_SB_MsgId_t    TestMsgId      = CFE_SB_ValueToMsgId(MM_SEND_HK_MID);
     CFE_MSG_FcnCode_t FcnCode        = 0;
     size_t            MsgSize        = 1;
@@ -160,7 +160,7 @@ void MM_VerifyCmdLength_Test_HKRequestLengthError(void)
 void MM_VerifyCmdLength_Test_LengthError(void)
 {
     bool              Result;
-    uint16            ExpectedLength = 99;
+    size_t            ExpectedLength = 99;
     CFE_SB_MsgId_t    TestMsgId      = MM_UT_MID_1;
     CFE_MSG_FcnCode_t FcnCode        = 0;
     size_t            MsgSize        = 1;
@@ -219,7 +219,7 @@ void MM_VerifyPeekPokeParams_Test_ByteWidthRAM(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_RAM;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -242,7 +242,7 @@ void MM_VerifyPeekPokeParams_Test_WordWidthMEM16(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_MEM16;
-    uint8        SizeInBits = 16;
+    size_t       SizeInBits = 16;
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -265,7 +265,7 @@ void MM_VerifyPeekPokeParams_Test_DWordWidthMEM32(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_MEM32;
-    uint8        SizeInBits = 32;
+    size_t       SizeInBits = 32;
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -288,12 +288,12 @@ void MM_VerifyPeekPokeParams_Test_WordWidthAlignmentError(void)
     bool         Result;
     uint32       Address    = 1;
     MM_MemType_t MemType    = MM_MEM16;
-    uint8        SizeInBits = 16;
+    size_t       SizeInBits = 16;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 16 bit aligned: Addr = %%p Size = %%d");
+             "Data and address not 16 bit aligned: Addr = %%p Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -323,12 +323,12 @@ void MM_VerifyPeekPokeParams_Test_DWordWidthAlignmentError(void)
     bool         Result;
     uint32       Address    = 1;
     MM_MemType_t MemType    = MM_MEM32;
-    uint8        SizeInBits = 32;
+    size_t       SizeInBits = 32;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 32 bit aligned: Addr = %%p Size = %%d");
+             "Data and address not 32 bit aligned: Addr = %%p Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -359,11 +359,11 @@ void MM_VerifyPeekPokeParams_Test_InvalidDataSize(void)
     uint32       Address = 0;
     MM_MemType_t MemType = MM_MEM8;
     /* To reach size error: Peeks and Pokes must be 8 bits wide for this memory type */
-    uint8 SizeInBits = 16;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    size_t SizeInBits = 16;
+    int32  strCmpResult;
+    char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Data size in bits invalid: Data Size = %%d");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Data size in bits invalid: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -393,7 +393,7 @@ void MM_VerifyPeekPokeParams_Test_EEPROM(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_EEPROM;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -416,7 +416,7 @@ void MM_VerifyPeekPokeParams_Test_MEM8(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_MEM8;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -439,12 +439,12 @@ void MM_VerifyPeekPokeParams_Test_RAMValidateRangeError(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_RAM;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = MEM_RAM");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = MEM_RAM");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -477,12 +477,12 @@ void MM_VerifyPeekPokeParams_Test_EEPROMValidateRangeError(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_EEPROM;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = MEM_EEPROM");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = MEM_EEPROM");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -515,12 +515,12 @@ void MM_VerifyPeekPokeParams_Test_MEM32ValidateRangeError(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_MEM32;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = MEM32");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = MEM32");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -553,12 +553,12 @@ void MM_VerifyPeekPokeParams_Test_MEM16ValidateRangeError(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_MEM16;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = MEM16");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = MEM16");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -591,12 +591,12 @@ void MM_VerifyPeekPokeParams_Test_MEM8ValidateRangeError(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_MEM8;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = MEM8");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = MEM8");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -629,11 +629,11 @@ void MM_VerifyPeekPokeParams_Test_MEM32InvalidDataSize(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_MEM32;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Data size in bits invalid: Data Size = %%d");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Data size in bits invalid: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -663,11 +663,11 @@ void MM_VerifyPeekPokeParams_Test_MEM16InvalidDataSize(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_MEM16;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Data size in bits invalid: Data Size = %%d");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Data size in bits invalid: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -697,11 +697,11 @@ void MM_VerifyPeekPokeParams_Test_MEM8InvalidDataSize(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = MM_MEM8;
-    uint8        SizeInBits = 99;
+    size_t       SizeInBits = 99;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Data size in bits invalid: Data Size = %%d");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Data size in bits invalid: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyPeekPokeParams(Address, MemType, SizeInBits);
@@ -731,7 +731,7 @@ void MM_VerifyPeekPokeParams_Test_InvalidMemType(void)
     bool         Result;
     uint32       Address    = 0;
     MM_MemType_t MemType    = 99;
-    uint8        SizeInBits = 8;
+    size_t       SizeInBits = 8;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -770,12 +770,12 @@ void MM_VerifyLoadDumpParams_Test_LoadRAMValidateRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -807,12 +807,12 @@ void MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -841,12 +841,12 @@ void MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = MM_MAX_LOAD_FILE_DATA_RAM + 1;
+    size_t       SizeInBytes = MM_MAX_LOAD_FILE_DATA_RAM + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -875,12 +875,12 @@ void MM_VerifyLoadDumpParams_Test_LoadEEPROMValidateRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -912,12 +912,12 @@ void MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -946,12 +946,12 @@ void MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = MM_MAX_LOAD_FILE_DATA_EEPROM + 1;
+    size_t       SizeInBytes = MM_MAX_LOAD_FILE_DATA_EEPROM + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -980,12 +980,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32ValidateRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 4;
+    size_t       SizeInBytes = 4;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1017,12 +1017,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -1051,12 +1051,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = MM_MAX_LOAD_FILE_DATA_MEM32 + 4;
+    size_t       SizeInBytes = MM_MAX_LOAD_FILE_DATA_MEM32 + 4;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -1085,12 +1085,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32AlignmentError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 32 bit aligned: Addr = %%p Size = %%d");
+             "Data and address not 32 bit aligned: Addr = %%p Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -1119,12 +1119,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16ValidateRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 2;
+    size_t       SizeInBytes = 2;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1156,12 +1156,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -1190,12 +1190,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = MM_MAX_LOAD_FILE_DATA_MEM16 + 2;
+    size_t       SizeInBytes = MM_MAX_LOAD_FILE_DATA_MEM16 + 2;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -1224,12 +1224,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16AlignmentError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 16 bit aligned: Addr = %%p Size = %%d");
+             "Data and address not 16 bit aligned: Addr = %%p Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -1258,12 +1258,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM8ValidateRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1295,12 +1295,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -1329,12 +1329,12 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = MM_MAX_LOAD_FILE_DATA_MEM8 + 1;
+    size_t       SizeInBytes = MM_MAX_LOAD_FILE_DATA_MEM8 + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_LOAD);
@@ -1363,7 +1363,7 @@ void MM_VerifyLoadDumpParams_Test_LoadInvalidMemTypeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = 99;
-    uint32       SizeInBytes = MM_MAX_LOAD_FILE_DATA_MEM8 + 1;
+    size_t       SizeInBytes = MM_MAX_LOAD_FILE_DATA_MEM8 + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -1396,7 +1396,7 @@ void MM_VerifyLoadDumpParams_Test_LoadInvalidVerifyTypeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = MM_MAX_LOAD_FILE_DATA_MEM8;
+    size_t       SizeInBytes = MM_MAX_LOAD_FILE_DATA_MEM8;
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, -1);
@@ -1419,7 +1419,7 @@ void MM_VerifyLoadDumpParams_Test_DumpRAM(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1442,7 +1442,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROM(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1465,7 +1465,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 4;
+    size_t       SizeInBytes = 4;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_PSP_MemValidateRange), CFE_PSP_SUCCESS);
 
@@ -1490,7 +1490,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 2;
+    size_t       SizeInBytes = 2;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_PSP_MemValidateRange), CFE_PSP_SUCCESS);
 
@@ -1515,7 +1515,7 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_PSP_MemValidateRange), CFE_PSP_SUCCESS);
 
@@ -1540,12 +1540,12 @@ void MM_VerifyLoadDumpParams_Test_DumpRAMRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1578,12 +1578,12 @@ void MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1613,12 +1613,12 @@ void MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = MM_MAX_DUMP_FILE_DATA_RAM + 1;
+    size_t       SizeInBytes = MM_MAX_DUMP_FILE_DATA_RAM + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1648,12 +1648,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROMRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1686,12 +1686,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1721,12 +1721,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = MM_MAX_DUMP_FILE_DATA_EEPROM + 1;
+    size_t       SizeInBytes = MM_MAX_DUMP_FILE_DATA_EEPROM + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1756,12 +1756,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32RangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 4;
+    size_t       SizeInBytes = 4;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1794,12 +1794,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1829,12 +1829,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = MM_MAX_DUMP_FILE_DATA_MEM32 + 4;
+    size_t       SizeInBytes = MM_MAX_DUMP_FILE_DATA_MEM32 + 4;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1864,12 +1864,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32AlignmentError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 3;
+    size_t       SizeInBytes = 3;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 32 bit aligned: Addr = %%p Size = %%d");
+             "Data and address not 32 bit aligned: Addr = %%p Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1899,12 +1899,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16RangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 2;
+    size_t       SizeInBytes = 2;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1937,12 +1937,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -1972,12 +1972,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = MM_MAX_DUMP_FILE_DATA_MEM16 + 2;
+    size_t       SizeInBytes = MM_MAX_DUMP_FILE_DATA_MEM16 + 2;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -2007,12 +2007,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16AlignmentError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 3;
+    size_t       SizeInBytes = 3;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 16 bit aligned: Addr = %%p Size = %%d");
+             "Data and address not 16 bit aligned: Addr = %%p Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -2042,12 +2042,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8RangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2080,12 +2080,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -2115,12 +2115,12 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = MM_MAX_DUMP_FILE_DATA_MEM8 + 1;
+    size_t       SizeInBytes = MM_MAX_DUMP_FILE_DATA_MEM8 + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_DUMP);
@@ -2150,7 +2150,7 @@ void MM_VerifyLoadDumpParams_Test_DumpInvalidMemoryType(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = 99;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -2189,7 +2189,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventRAM(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2212,7 +2212,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventEEPROM(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2235,7 +2235,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 4;
+    size_t       SizeInBytes = 4;
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2258,7 +2258,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 2;
+    size_t       SizeInBytes = 2;
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2281,7 +2281,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM8(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2304,12 +2304,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2339,12 +2339,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = MM_MAX_DUMP_INEVENT_BYTES + 1;
+    size_t       SizeInBytes = MM_MAX_DUMP_INEVENT_BYTES + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2374,12 +2374,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEventRAMRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2412,12 +2412,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEventEEPROMRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2450,12 +2450,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32RangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 4;
+    size_t       SizeInBytes = 4;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2488,12 +2488,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32AlignmentError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 3;
+    size_t       SizeInBytes = 3;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 32 bit aligned: Addr = %%p Size = %%d");
+             "Data and address not 32 bit aligned: Addr = %%p Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2523,12 +2523,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16RangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 2;
+    size_t       SizeInBytes = 2;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2561,12 +2561,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16AlignmentError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 3;
+    size_t       SizeInBytes = 3;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 16 bit aligned: Addr = %%p Size = %%d");
+             "Data and address not 16 bit aligned: Addr = %%p Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_EVENT);
@@ -2596,12 +2596,12 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM8RangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2634,7 +2634,7 @@ void MM_VerifyLoadDumpParams_Test_DumpEventInvalidMemType(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = 99;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -2673,12 +2673,12 @@ void MM_VerifyLoadDumpParams_Test_FillRAMValidateRangeError(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2710,12 +2710,12 @@ void MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooSmall(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -2744,12 +2744,12 @@ void MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooLarge(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_RAM;
-    uint32       SizeInBytes = MM_MAX_FILL_DATA_RAM + 1;
+    size_t       SizeInBytes = MM_MAX_FILL_DATA_RAM + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -2778,12 +2778,12 @@ void MM_VerifyLoadDumpParams_Test_FillEEPROMValidateRangeError(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2815,12 +2815,12 @@ void MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooSmall(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -2849,12 +2849,12 @@ void MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooLarge(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_EEPROM;
-    uint32       SizeInBytes = MM_MAX_FILL_DATA_EEPROM + 1;
+    size_t       SizeInBytes = MM_MAX_FILL_DATA_EEPROM + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -2883,12 +2883,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32ValidateRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 4;
+    size_t       SizeInBytes = 4;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -2920,12 +2920,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -2954,12 +2954,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = MM_MAX_FILL_DATA_MEM32 + 4;
+    size_t       SizeInBytes = MM_MAX_FILL_DATA_MEM32 + 4;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -2988,12 +2988,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32AlignmentError(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_MEM32;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 32 bit aligned: Addr = %%p Size = %%d");
+             "Data and address not 32 bit aligned: Addr = %%p Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -3022,12 +3022,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16ValidateRangeError(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 2;
+    size_t       SizeInBytes = 2;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -3059,12 +3059,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooSmall(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -3093,12 +3093,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooLarge(void)
     bool         Result;
     uint32       Address     = 0;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = MM_MAX_FILL_DATA_MEM16 + 2;
+    size_t       SizeInBytes = MM_MAX_FILL_DATA_MEM16 + 2;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -3127,12 +3127,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16AlignmentError(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_MEM16;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data and address not 16 bit aligned: Addr = %%p Size = %%d");
+             "Data and address not 16 bit aligned: Addr = %%p Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -3161,12 +3161,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM8ValidateRangeError(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -3198,12 +3198,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooSmall(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = 0;
+    size_t       SizeInBytes = 0;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -3232,12 +3232,12 @@ void MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooLarge(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = MM_MEM8;
-    uint32       SizeInBytes = MM_MAX_FILL_DATA_MEM8 + 1;
+    size_t       SizeInBytes = MM_MAX_FILL_DATA_MEM8 + 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MemType, SizeInBytes, MM_VERIFY_FILL);
@@ -3266,7 +3266,7 @@ void MM_VerifyLoadDumpParams_Test_FillInvalidMemTypeError(void)
     bool         Result;
     uint32       Address     = 1;
     MM_MemType_t MemType     = 99;
-    uint32       SizeInBytes = 1;
+    size_t       SizeInBytes = 1;
     int32        strCmpResult;
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -3298,7 +3298,7 @@ void MM_VerifyLoadDumpParams_Test_FillInvalidMemTypeError(void)
 void MM_VerifyLoadDumpParams_Test_WIDNominal(void)
 {
     uint32 Address     = 0;
-    uint32 SizeInBytes = 1;
+    size_t SizeInBytes = 1;
     bool   Result;
 
     /* Execute the function being tested */
@@ -3319,13 +3319,13 @@ void MM_VerifyLoadDumpParams_Test_WIDNominal(void)
 void MM_VerifyLoadDumpParams_Test_WIDMemValidateError(void)
 {
     uint32 Address     = 0;
-    uint32 SizeInBytes = 1;
+    size_t SizeInBytes = 1;
     int32  strCmpResult;
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     bool   Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%d MemType = %%s");
+             "CFE_PSP_MemValidateRange error received: RC = 0x%%08X Addr = %%p Size = %%u MemType = %%s");
 
     /* Set to generate error message MM_OS_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -3356,13 +3356,13 @@ void MM_VerifyLoadDumpParams_Test_WIDMemValidateError(void)
 void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooSmall(void)
 {
     uint32 Address     = 0;
-    uint32 SizeInBytes = 0;
+    size_t SizeInBytes = 0;
     int32  strCmpResult;
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     bool   Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MM_RAM, SizeInBytes, MM_VERIFY_WID);
@@ -3390,13 +3390,13 @@ void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooSmall(void)
 void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooLarge(void)
 {
     uint32 Address     = 0;
-    uint32 SizeInBytes = MM_MAX_UNINTERRUPTIBLE_DATA + 1;
+    size_t SizeInBytes = MM_MAX_UNINTERRUPTIBLE_DATA + 1;
     int32  strCmpResult;
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     bool   Result;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Data size in bytes invalid or exceeds limits: Data Size = %%d");
+             "Data size in bytes invalid or exceeds limits: Data Size = %%u");
 
     /* Execute the function being tested */
     Result = MM_VerifyLoadDumpParams(Address, MM_RAM, SizeInBytes, MM_VERIFY_WID);
@@ -3425,7 +3425,7 @@ void MM_Verify32Aligned_Test(void)
 {
     bool    Result;
     cpuaddr Addr;
-    uint32  Size;
+    size_t  Size;
 
     Addr = 0; /* address is aligned */
     Size = 4; /* size is aligned */
@@ -3459,7 +3459,7 @@ void MM_Verify16Aligned_Test(void)
 {
     bool    Result;
     cpuaddr Addr;
-    uint32  Size;
+    size_t  Size;
 
     Addr = 0; /* address is aligned */
     Size = 4; /* size is aligned */

--- a/unit-test/stubs/mm_utils_stubs.c
+++ b/unit-test/stubs/mm_utils_stubs.c
@@ -55,7 +55,7 @@ bool MM_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
     return UT_DEFAULT_IMPL(MM_VerifyCmdLength);
 }
 
-bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeInBits)
+bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, size_t SizeInBits)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MM_VerifyPeekPokeParams), Address);
     UT_Stub_RegisterContextGenericArg(UT_KEY(MM_VerifyPeekPokeParams), MemType);
@@ -63,7 +63,7 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
     return UT_DEFAULT_IMPL(MM_VerifyPeekPokeParams);
 }
 
-bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeInBytes, uint8 VerifyType)
+bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, size_t SizeInBytes, uint8 VerifyType)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MM_VerifyLoadDumpParams), Address);
     UT_Stub_RegisterContextGenericArg(UT_KEY(MM_VerifyLoadDumpParams), MemType);
@@ -72,14 +72,14 @@ bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeI
     return UT_DEFAULT_IMPL(MM_VerifyLoadDumpParams);
 }
 
-bool MM_Verify32Aligned(cpuaddr Address, uint32 Size)
+bool MM_Verify32Aligned(cpuaddr Address, size_t Size)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MM_Verify32Aligned), Address);
     UT_Stub_RegisterContextGenericArg(UT_KEY(MM_Verify32Aligned), Size);
     return UT_DEFAULT_IMPL(MM_Verify32Aligned) != 0;
 }
 
-bool MM_Verify16Aligned(cpuaddr Address, uint32 Size)
+bool MM_Verify16Aligned(cpuaddr Address, size_t Size)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MM_Verify16Aligned), Address);
     UT_Stub_RegisterContextGenericArg(UT_KEY(MM_Verify16Aligned), Size);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #67 
  - Converted the obvious candidates for conversion to `size_t` (mostly local variables).
  - Updated the related local test variables to `size_t` as well for consistency.
  - All variables updated were already unsigned (`uint8,` `uint16` and mostly `uint32`).

4 functions had parameters converted to `size_t:`
`MM_Verify32Aligned()` - `uint32 Size`
`MM_Verify16Aligned()` - `uint32 Size`
`MM_VerifyLoadDumpParams()` - `uint32 SizeInBytes`
`MM_VerifyPeekPokeParams()` - `uint8 SizeInBits`

Even if using `size_t` is unnecessary in some cases (and wastes some space), it is more expressive and more compliant with the relevant coding standards.

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior other than type changes outlined above.

**Contributor Info**
Avi Weiss @thnkslprpt