### PR TITLE
Fix #70, Remove redundant use of "dummy" in test code

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,7 +3,7 @@ name: CodeQl Analysis
 on:
   push:
   pull_request:
-  
+
 
 jobs:
   codeql:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -9,4 +9,3 @@ jobs:
   format-check:
     name: Run format check
     uses: nasa/cFS/.github/workflows/format-check.yml@main
-    

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,4 +10,4 @@ jobs:
     name: Run cppcheck
     uses: nasa/cFS/.github/workflows/static-analysis.yml@main
     with:
-      strict-dir-list: './fsw'    
+      strict-dir-list: './fsw'

--- a/docs/dox_src/cfs_mm.dox
+++ b/docs/dox_src/cfs_mm.dox
@@ -54,7 +54,7 @@
 
   This document provides a complete specification for the commands and telemetry associated
   with the CFS Memory Manager (MM) application software.  The document is intended primarily 
-  for users of the software (operations personal, test engineers, and maintenance personnel).  
+  for users of the software (operations personnel, test engineers, and maintenance personnel).  
   The last section of the document, the deployment guide section, is intended for mission 
   developers when deploying and configuring the MM application software for a mission 
   flight software build environment. 
@@ -127,7 +127,7 @@
   application. MM also does not have responsibility for file management operations or directory 
   manipulations. That function is allocated to the CFS FM (File Manager) application.  
 
-  MM is a command driven, single threaded application. It will pend indefinitely on the software bus
+  MM is a command driven, single-threaded application. It will pend indefinitely on the software bus
   message queue until commands are received and then process them sequentially in the order they 
   arrived. Memory Manager segments loads and dumps in order to prevent CPU hogging. Despite this, 
   careful consideration should be made when loading and dumping large amounts of memory. See

--- a/fsw/src/mm_dump.c
+++ b/fsw/src/mm_dump.c
@@ -426,7 +426,7 @@ bool MM_DumpMemToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadD
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Write the cFE primary and and MM secondary file headers         */
+/* Write the cFE primary and MM secondary file headers         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_WriteFileHeaders(const char *FileName, osal_id_t FileHandle, CFE_FS_Header_t *CFEHeader,

--- a/fsw/src/mm_dump.h
+++ b/fsw/src/mm_dump.h
@@ -99,7 +99,7 @@ bool MM_PeekMem(const MM_PeekCmd_t *CmdPtr, cpuaddr SrcAddress);
 bool MM_DumpMemToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader);
 
 /**
- * \brief Write the cFE primary and and MM secondary file headers
+ * \brief Write the cFE primary and MM secondary file headers
  *
  *  \par Description
  *       Support function for #MM_DumpMemToFileCmd. This routine will

--- a/fsw/src/mm_load.c
+++ b/fsw/src/mm_load.c
@@ -671,7 +671,7 @@ bool MM_VerifyLoadFileSize(const char *FileName, const MM_LoadDumpFileHeader_t *
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Read the cFE primary and and MM secondary file headers          */
+/* Read the cFE primary and MM secondary file headers          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_ReadFileHeaders(const char *FileName, osal_id_t FileHandle, CFE_FS_Header_t *CFEHeader,

--- a/fsw/src/mm_load.h
+++ b/fsw/src/mm_load.h
@@ -132,7 +132,7 @@ bool MM_LoadMemFromFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
 bool MM_VerifyLoadFileSize(const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader);
 
 /**
- * \brief Read the cFE primary and and MM secondary file headers
+ * \brief Read the cFE primary and MM secondary file headers
  *
  *  \par Description
  *       Support function for #MM_LoadMemFromFileCmd. This routine will

--- a/unit-test/mm_dump_tests.c
+++ b/unit-test/mm_dump_tests.c
@@ -53,7 +53,7 @@
 /* mm_dump_tests globals */
 uint8 call_count_CFE_EVS_SendEvent;
 
-uint8 DummyBuffer[MM_MAX_FILL_DATA_SEG * 2];
+uint8 Buffer[MM_MAX_FILL_DATA_SEG * 2];
 
 /*
  * Function Definitions
@@ -64,7 +64,7 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook1(void *UserObj, int32 StubRetcode, ui
 {
     cpuaddr *ResolvedAddress = (cpuaddr *)Context->ArgPtr[1];
 
-    *ResolvedAddress = (cpuaddr)DummyBuffer;
+    *ResolvedAddress = (cpuaddr)Buffer;
 
     return true;
 }
@@ -75,7 +75,7 @@ int32 UT_MM_LOAD_TEST_OS_WriteHook1(void *UserObj, int32 StubRetcode, uint32 Cal
 
     cpuaddr *ResolvedAddress = (cpuaddr *)&header->SymAddress.Offset;
 
-    *ResolvedAddress = (cpuaddr)DummyBuffer;
+    *ResolvedAddress = (cpuaddr)Buffer;
 
     return sizeof(MM_LoadDumpFileHeader_t);
 }
@@ -523,7 +523,7 @@ void MM_DumpMemToFileCmd_Test_RAM(void)
 
     strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
             sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = (cpuaddr)&DummyBuffer[0];
+    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
 
     UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_RAM;
     UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
@@ -594,7 +594,7 @@ void MM_DumpMemToFileCmd_Test_BadType(void)
 
     strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
             sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = (cpuaddr)&DummyBuffer[0];
+    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
 
     UT_CmdBuf.DumpMemToFileCmd.MemType    = 99;
     UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
@@ -651,7 +651,7 @@ void MM_DumpMemToFileCmd_Test_EEPROM(void)
 
     strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
             sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = (cpuaddr)&DummyBuffer[0];
+    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
 
     UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_EEPROM;
     UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
@@ -1724,7 +1724,7 @@ void MM_DumpInEventCmd_Test_Nominal(void)
 
     UT_CmdBuf.DumpInEventCmd.MemType              = MM_RAM;
     UT_CmdBuf.DumpInEventCmd.NumOfBytes           = 1;
-    UT_CmdBuf.DumpInEventCmd.SrcSymAddress.Offset = (cpuaddr)&DummyBuffer[0];
+    UT_CmdBuf.DumpInEventCmd.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
 
     UT_CmdBuf.DumpInEventCmd.SrcSymAddress.SymName[0] = '\0';
 
@@ -1904,7 +1904,7 @@ void MM_DumpInEventCmd_Test_FillDumpInvalid(void)
 
     UT_CmdBuf.DumpInEventCmd.MemType              = MM_MEM8;
     UT_CmdBuf.DumpInEventCmd.NumOfBytes           = 1;
-    UT_CmdBuf.DumpInEventCmd.SrcSymAddress.Offset = (cpuaddr)&DummyBuffer[0];
+    UT_CmdBuf.DumpInEventCmd.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
 
     UT_CmdBuf.DumpInEventCmd.SrcSymAddress.SymName[0] = '\0';
 

--- a/unit-test/mm_load_tests.c
+++ b/unit-test/mm_load_tests.c
@@ -57,7 +57,7 @@ MM_LoadDumpFileHeader_t MMHeaderSave;
 
 MM_LoadDumpFileHeader_t *MMHeaderRestore;
 
-uint8 DummyBuffer[MM_MAX_FILL_DATA_SEG * 2];
+uint8 Buffer[MM_MAX_FILL_DATA_SEG * 2];
 
 /*
  * Function Definitions
@@ -90,7 +90,7 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook1(void *UserObj, int32 StubRetcode, ui
     uint32 * SymbolAddress   = (uint32 *)Context->ArgPtr[0];
     cpuaddr *ResolvedAddress = (cpuaddr *)Context->ArgPtr[1];
 
-    *ResolvedAddress = (cpuaddr)DummyBuffer;
+    *ResolvedAddress = (cpuaddr)Buffer;
     *SymbolAddress   = 0;
     *MMHeaderRestore = MMHeaderSave;
 
@@ -103,7 +103,7 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook2(void *UserObj, int32 StubRetcode, ui
     uint32 * SymbolAddress   = (uint32 *)Context->ArgPtr[0];
     cpuaddr *ResolvedAddress = (cpuaddr *)Context->ArgPtr[1];
 
-    *ResolvedAddress = (cpuaddr)DummyBuffer;
+    *ResolvedAddress = (cpuaddr)Buffer;
     *SymbolAddress   = 0;
     *MMHeaderRestore = MMHeaderSave;
 
@@ -115,7 +115,7 @@ int32 UT_MM_LOAD_TEST_CFE_SymbolLookupHook3(void *UserObj, int32 StubRetcode, ui
 {
     cpuaddr *ResolvedAddress = (cpuaddr *)Context->ArgPtr[1];
 
-    *ResolvedAddress = (cpuaddr)DummyBuffer;
+    *ResolvedAddress = (cpuaddr)Buffer;
 
     return true;
 }
@@ -2104,14 +2104,14 @@ void MM_LoadMemFromFile_Test_PreventCPUHogging(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_read), MM_MAX_LOAD_DATA_SEG);
 
     /* Execute the function being tested */
-    Result = MM_LoadMemFromFile(MM_UT_OBJID_1, FileName, &FileHeader, (cpuaddr)&DummyBuffer[0]);
+    Result = MM_LoadMemFromFile(MM_UT_OBJID_1, FileName, &FileHeader, (cpuaddr)&Buffer[0]);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
     UtAssert_True(MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE,
                   "MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE");
     UtAssert_True(MM_AppData.HkPacket.MemType == MM_EEPROM, "MM_AppData.HkPacket.MemType == MM_EEPROM");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)(&DummyBuffer[0]), "MM_AppData.HkPacket.Address == 0");
+    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)(&Buffer[0]), "MM_AppData.HkPacket.Address == 0");
     UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 2 * MM_MAX_LOAD_DATA_SEG,
                   "MM_AppData.HkPacket.BytesProcessed == 2*MM_MAX_LOAD_DATA_SEG");
     UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName), FileName,
@@ -2142,7 +2142,7 @@ void MM_LoadMemFromFile_Test_ReadError(void)
     UT_SetDeferredRetcode(UT_KEY(OS_read), 1, 0);
 
     /* Execute the function being tested */
-    Result = MM_LoadMemFromFile(MM_UT_OBJID_1, (char *)"filename", &FileHeader, (cpuaddr)&DummyBuffer[0]);
+    Result = MM_LoadMemFromFile(MM_UT_OBJID_1, (char *)"filename", &FileHeader, (cpuaddr)&Buffer[0]);
 
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");
@@ -2176,14 +2176,14 @@ void MM_LoadMemFromFile_Test_NotEepromMemType(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_read), MM_MAX_LOAD_DATA_SEG);
 
     /* Execute the function being tested */
-    Result = MM_LoadMemFromFile(MM_UT_OBJID_1, FileName, &FileHeader, (cpuaddr)&DummyBuffer[0]);
+    Result = MM_LoadMemFromFile(MM_UT_OBJID_1, FileName, &FileHeader, (cpuaddr)&Buffer[0]);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
     UtAssert_True(MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE,
                   "MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE");
     UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM8, "MM_AppData.HkPacket.MemType == MM_MEM8");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)(&DummyBuffer[0]), "MM_AppData.HkPacket.Address == 0");
+    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)(&Buffer[0]), "MM_AppData.HkPacket.Address == 0");
     UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 2 * MM_MAX_LOAD_DATA_SEG,
                   "MM_AppData.HkPacket.BytesProcessed == 2*MM_MAX_LOAD_DATA_SEG");
     UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName), FileName,
@@ -2718,18 +2718,17 @@ void MM_FillMem_Test_Nominal(void)
 
     CmdPacket.MemType    = MM_EEPROM;
     CmdPacket.NumOfBytes = 2;
-    memset(DummyBuffer, 1, (MM_MAX_FILL_DATA_SEG * 2));
+    memset(Buffer, 1, (MM_MAX_FILL_DATA_SEG * 2));
 
     /* Execute the function being tested */
-    Result = MM_FillMem((cpuaddr)DummyBuffer, &CmdPacket);
+    Result = MM_FillMem((cpuaddr)Buffer, &CmdPacket);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
     UtAssert_True(MM_AppData.HkPacket.LastAction == MM_FILL, "MM_AppData.HkPacket.LastAction == MM_FILL");
     UtAssert_True(MM_AppData.HkPacket.MemType == CmdPacket.MemType, "MM_AppData.HkPacket.MemType == CmdPacket.MemType");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)DummyBuffer,
-                  "MM_AppData.HkPacket.Address == (cpuaddr)DummyBuffer");
+    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)Buffer, "MM_AppData.HkPacket.Address == (cpuaddr)Buffer");
     UtAssert_True(MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern,
                   "MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern");
     UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 2, "MM_AppData.HkPacket.BytesProcessed == 2");
@@ -2753,17 +2752,16 @@ void MM_FillMem_Test_MaxFillDataSegment(void)
     CmdPacket.MemType    = MM_EEPROM;
     CmdPacket.NumOfBytes = MM_MAX_FILL_DATA_SEG + 1;
 
-    memset(DummyBuffer, 1, (MM_MAX_FILL_DATA_SEG * 2));
+    memset(Buffer, 1, (MM_MAX_FILL_DATA_SEG * 2));
     /* Execute the function being tested */
-    Result = MM_FillMem((cpuaddr)DummyBuffer, &CmdPacket);
+    Result = MM_FillMem((cpuaddr)Buffer, &CmdPacket);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
     UtAssert_True(MM_AppData.HkPacket.LastAction == MM_FILL, "MM_AppData.HkPacket.LastAction == MM_FILL");
     UtAssert_True(MM_AppData.HkPacket.MemType == CmdPacket.MemType, "MM_AppData.HkPacket.MemType == CmdPacket.MemType");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)DummyBuffer,
-                  "MM_AppData.HkPacket.Address == (cpuaddr)DummyBuffer");
+    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)Buffer, "MM_AppData.HkPacket.Address == (cpuaddr)Buffer");
     UtAssert_True(MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern,
                   "MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern");
     UtAssert_True(MM_AppData.HkPacket.BytesProcessed == MM_MAX_FILL_DATA_SEG + 1,


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #70 
  - Redundant use of the word "dummy" in test code variables/text has been removed

**Testing performed**
GitHub CI actions all passing successfully (incl. unit tests etc.)

**Expected behavior changes**
No change to behavior.
Test code is simpler and cleaner when redundant qualifiers are removed.

**Contributor Info**
Avi Weiss @thnkslprpt