### PR TITLE
Fix #72, Convert `int32` return codes and variables to `CFE_Status_t`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#core Flight System (cFS) Memory Manager Application (MM)
+# core Flight System (cFS) Memory Manager Application (MM)
 
 ## Introduction
 

--- a/fsw/src/mm_app.c
+++ b/fsw/src/mm_app.c
@@ -51,7 +51,7 @@ MM_AppData_t MM_AppData;
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void MM_AppMain(void)
 {
-    int32            Status = CFE_SUCCESS;
+    CFE_Status_t     Status = CFE_SUCCESS;
     CFE_SB_Buffer_t *BufPtr = NULL;
 
     /*
@@ -127,9 +127,9 @@ void MM_AppMain(void)
 /* MM initialization                                               */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 MM_AppInit(void)
+CFE_Status_t MM_AppInit(void)
 {
-    int32 Status = CFE_SUCCESS;
+    CFE_Status_t Status = CFE_SUCCESS;
 
     /*
     ** MM doesn't use the critical data store and
@@ -544,7 +544,7 @@ bool MM_SymTblToFileCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_EepromWriteEnaCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    int32                   cFE_Status     = CFE_PSP_ERROR; /* Set to error since we explicitly test for success */
+    CFE_Status_t            cFE_Status     = CFE_PSP_ERROR; /* Set to error since we explicitly test for success */
     MM_EepromWriteEnaCmd_t *CmdPtr         = NULL;
     size_t                  ExpectedLength = sizeof(MM_EepromWriteEnaCmd_t);
     bool                    Result         = false;
@@ -590,7 +590,7 @@ bool MM_EepromWriteEnaCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_EepromWriteDisCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    int32                   cFE_Status     = CFE_PSP_ERROR; /* Set to error since we explicitly test for success */
+    CFE_Status_t            cFE_Status     = CFE_PSP_ERROR; /* Set to error since we explicitly test for success */
     MM_EepromWriteDisCmd_t *CmdPtr         = NULL;
     size_t                  ExpectedLength = sizeof(MM_EepromWriteDisCmd_t);
     bool                    Result         = false;

--- a/fsw/src/mm_app.h
+++ b/fsw/src/mm_app.h
@@ -113,7 +113,7 @@ void MM_AppMain(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 MM_AppInit(void);
+CFE_Status_t MM_AppInit(void);
 
 /**
  * \brief Process a command pipe message

--- a/fsw/src/mm_load.c
+++ b/fsw/src/mm_load.c
@@ -105,14 +105,14 @@ bool MM_PokeCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_PokeMem(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
 {
-    uint8  ByteValue;
-    uint16 WordValue;
-    int32  PSP_Status     = CFE_PSP_SUCCESS;
-    uint32 DataValue      = 0;
-    uint32 BytesProcessed = 0;
-    bool   ValidPoke      = false;
-    uint8  DataSize       = 0; /* only used for giving MEM type/size in events */
-    uint32 EventID        = 0;
+    uint8        ByteValue;
+    uint16       WordValue;
+    CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
+    uint32       DataValue      = 0;
+    uint32       BytesProcessed = 0;
+    bool         ValidPoke      = false;
+    uint8        DataSize       = 0; /* only used for giving MEM type/size in events */
+    uint32       EventID        = 0;
 
     /* Write input number of bits to destination address */
     switch (CmdPtr->DataSize)
@@ -190,12 +190,12 @@ bool MM_PokeMem(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_PokeEeprom(const MM_PokeCmd_t *CmdPtr, cpuaddr DestAddress)
 {
-    uint8  ByteValue;
-    uint16 WordValue;
-    int32  PSP_Status;
-    uint32 DataValue      = 0;
-    uint32 BytesProcessed = 0;
-    bool   ValidPoke      = false;
+    uint8        ByteValue;
+    uint16       WordValue;
+    CFE_Status_t PSP_Status;
+    uint32       DataValue      = 0;
+    uint32       BytesProcessed = 0;
+    bool         ValidPoke      = false;
 
     CFE_ES_PerfLogEntry(MM_EEPROM_POKE_PERF_ID);
 

--- a/fsw/src/mm_mem16.c
+++ b/fsw/src/mm_mem16.c
@@ -51,15 +51,15 @@ extern MM_AppData_t MM_AppData;
 bool MM_LoadMem16FromFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader,
                           cpuaddr DestAddress)
 {
-    uint32  i;
-    int32   ReadLength;
-    int32   PSP_Status     = CFE_PSP_SUCCESS;
-    int32   BytesProcessed = 0;
-    int32   BytesRemaining = FileHeader->NumOfBytes;
-    uint16 *DataPointer16  = (uint16 *)DestAddress;
-    uint16 *ioBuffer16     = (uint16 *)&MM_AppData.LoadBuffer[0];
-    uint32  SegmentSize    = MM_MAX_LOAD_DATA_SEG;
-    bool    Valid          = false;
+    uint32       i;
+    int32        ReadLength;
+    CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
+    int32        BytesProcessed = 0;
+    int32        BytesRemaining = FileHeader->NumOfBytes;
+    uint16 *     DataPointer16  = (uint16 *)DestAddress;
+    uint16 *     ioBuffer16     = (uint16 *)&MM_AppData.LoadBuffer[0];
+    uint32       SegmentSize    = MM_MAX_LOAD_DATA_SEG;
+    bool         Valid          = false;
 
     while (BytesRemaining != 0)
     {
@@ -134,15 +134,15 @@ bool MM_LoadMem16FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_DumpMem16ToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader)
 {
-    bool    Valid = true;
-    int32   OS_Status;
-    int32   PSP_Status = CFE_PSP_SUCCESS;
-    uint32  i;
-    uint32  BytesProcessed = 0;
-    uint32  BytesRemaining = FileHeader->NumOfBytes;
-    uint16 *DataPointer16  = (uint16 *)(FileHeader->SymAddress.Offset);
-    uint16 *ioBuffer16     = (uint16 *)&MM_AppData.DumpBuffer[0];
-    uint32  SegmentSize    = MM_MAX_DUMP_DATA_SEG;
+    bool         Valid = true;
+    int32        OS_Status;
+    CFE_Status_t PSP_Status = CFE_PSP_SUCCESS;
+    uint32       i;
+    uint32       BytesProcessed = 0;
+    uint32       BytesRemaining = FileHeader->NumOfBytes;
+    uint16 *     DataPointer16  = (uint16 *)(FileHeader->SymAddress.Offset);
+    uint16 *     ioBuffer16     = (uint16 *)&MM_AppData.DumpBuffer[0];
+    uint32       SegmentSize    = MM_MAX_DUMP_DATA_SEG;
 
     while (BytesRemaining != 0)
     {
@@ -220,15 +220,15 @@ bool MM_DumpMem16ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_FillMem16(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
 {
-    uint32  i;
-    int32   PSP_Status     = CFE_PSP_SUCCESS;
-    uint32  BytesProcessed = 0;
-    uint32  BytesRemaining = CmdPtr->NumOfBytes;
-    uint32  NewBytesRemaining;
-    uint16  FillPattern16 = (uint16)CmdPtr->FillPattern;
-    uint16 *DataPointer16 = (uint16 *)DestAddress;
-    uint32  SegmentSize   = MM_MAX_FILL_DATA_SEG;
-    bool    Result        = true;
+    uint32       i;
+    CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
+    uint32       BytesProcessed = 0;
+    uint32       BytesRemaining = CmdPtr->NumOfBytes;
+    uint32       NewBytesRemaining;
+    uint16       FillPattern16 = (uint16)CmdPtr->FillPattern;
+    uint16 *     DataPointer16 = (uint16 *)DestAddress;
+    uint32       SegmentSize   = MM_MAX_FILL_DATA_SEG;
+    bool         Result        = true;
 
     /* Check fill size and warn if not a multiple of 2 */
     if ((BytesRemaining % 2) != 0)

--- a/fsw/src/mm_mem32.c
+++ b/fsw/src/mm_mem32.c
@@ -51,15 +51,15 @@ extern MM_AppData_t MM_AppData;
 bool MM_LoadMem32FromFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader,
                           cpuaddr DestAddress)
 {
-    uint32  i;
-    int32   ReadLength;
-    int32   PSP_Status     = CFE_PSP_SUCCESS;
-    int32   BytesProcessed = 0;
-    int32   BytesRemaining = FileHeader->NumOfBytes;
-    uint32 *DataPointer32  = (uint32 *)DestAddress;
-    uint32 *ioBuffer32     = (uint32 *)&MM_AppData.LoadBuffer[0];
-    uint32  SegmentSize    = MM_MAX_LOAD_DATA_SEG;
-    bool    Valid          = false;
+    uint32       i;
+    int32        ReadLength;
+    CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
+    int32        BytesProcessed = 0;
+    int32        BytesRemaining = FileHeader->NumOfBytes;
+    uint32 *     DataPointer32  = (uint32 *)DestAddress;
+    uint32 *     ioBuffer32     = (uint32 *)&MM_AppData.LoadBuffer[0];
+    uint32       SegmentSize    = MM_MAX_LOAD_DATA_SEG;
+    bool         Valid          = false;
 
     while (BytesRemaining != 0)
     {
@@ -134,15 +134,15 @@ bool MM_LoadMem32FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_DumpMem32ToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader)
 {
-    bool    Valid = true;
-    int32   OS_Status;
-    int32   PSP_Status = CFE_PSP_SUCCESS;
-    uint32  i;
-    uint32  BytesProcessed = 0;
-    uint32  BytesRemaining = FileHeader->NumOfBytes;
-    uint32 *DataPointer32  = (uint32 *)(FileHeader->SymAddress.Offset);
-    uint32 *ioBuffer32     = (uint32 *)&MM_AppData.DumpBuffer[0];
-    uint32  SegmentSize    = MM_MAX_DUMP_DATA_SEG;
+    bool         Valid = true;
+    int32        OS_Status;
+    CFE_Status_t PSP_Status = CFE_PSP_SUCCESS;
+    uint32       i;
+    uint32       BytesProcessed = 0;
+    uint32       BytesRemaining = FileHeader->NumOfBytes;
+    uint32 *     DataPointer32  = (uint32 *)(FileHeader->SymAddress.Offset);
+    uint32 *     ioBuffer32     = (uint32 *)&MM_AppData.DumpBuffer[0];
+    uint32       SegmentSize    = MM_MAX_DUMP_DATA_SEG;
 
     while (BytesRemaining != 0)
     {
@@ -221,15 +221,15 @@ bool MM_DumpMem32ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_FillMem32(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
 {
-    uint32  i;
-    int32   PSP_Status     = CFE_PSP_SUCCESS;
-    uint32  BytesProcessed = 0;
-    uint32  BytesRemaining = CmdPtr->NumOfBytes;
-    uint32  NewBytesRemaining;
-    uint32  FillPattern32 = CmdPtr->FillPattern;
-    uint32 *DataPointer32 = (uint32 *)(DestAddress);
-    uint32  SegmentSize   = MM_MAX_FILL_DATA_SEG;
-    bool    Result        = true;
+    uint32       i;
+    CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
+    uint32       BytesProcessed = 0;
+    uint32       BytesRemaining = CmdPtr->NumOfBytes;
+    uint32       NewBytesRemaining;
+    uint32       FillPattern32 = CmdPtr->FillPattern;
+    uint32 *     DataPointer32 = (uint32 *)(DestAddress);
+    uint32       SegmentSize   = MM_MAX_FILL_DATA_SEG;
+    bool         Result        = true;
 
     /* Check fill size and warn if not a multiple of 4 */
     if ((BytesRemaining % 4) != 0)

--- a/fsw/src/mm_mem8.c
+++ b/fsw/src/mm_mem8.c
@@ -51,15 +51,15 @@ extern MM_AppData_t MM_AppData;
 bool MM_LoadMem8FromFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader,
                          cpuaddr DestAddress)
 {
-    uint32 i;
-    int32  ReadLength;
-    int32  PSP_Status     = CFE_PSP_SUCCESS;
-    int32  BytesProcessed = 0;
-    int32  BytesRemaining = FileHeader->NumOfBytes;
-    uint8 *DataPointer8   = (uint8 *)DestAddress;
-    uint8 *ioBuffer8      = (uint8 *)&MM_AppData.LoadBuffer[0];
-    uint32 SegmentSize    = MM_MAX_LOAD_DATA_SEG;
-    bool   Valid          = false;
+    uint32       i;
+    int32        ReadLength;
+    CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
+    int32        BytesProcessed = 0;
+    int32        BytesRemaining = FileHeader->NumOfBytes;
+    uint8 *      DataPointer8   = (uint8 *)DestAddress;
+    uint8 *      ioBuffer8      = (uint8 *)&MM_AppData.LoadBuffer[0];
+    uint32       SegmentSize    = MM_MAX_LOAD_DATA_SEG;
+    bool         Valid          = false;
 
     while (BytesRemaining != 0)
     {
@@ -134,15 +134,15 @@ bool MM_LoadMem8FromFile(osal_id_t FileHandle, const char *FileName, const MM_Lo
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_DumpMem8ToFile(osal_id_t FileHandle, const char *FileName, const MM_LoadDumpFileHeader_t *FileHeader)
 {
-    bool   Valid = true;
-    int32  OS_Status;
-    int32  PSP_Status = CFE_PSP_SUCCESS;
-    uint32 i;
-    uint32 BytesProcessed = 0;
-    uint32 BytesRemaining = FileHeader->NumOfBytes;
-    uint8 *DataPointer8   = (uint8 *)(FileHeader->SymAddress.Offset);
-    uint8 *ioBuffer8      = (uint8 *)&MM_AppData.DumpBuffer[0];
-    uint32 SegmentSize    = MM_MAX_DUMP_DATA_SEG;
+    bool         Valid = true;
+    int32        OS_Status;
+    CFE_Status_t PSP_Status = CFE_PSP_SUCCESS;
+    uint32       i;
+    uint32       BytesProcessed = 0;
+    uint32       BytesRemaining = FileHeader->NumOfBytes;
+    uint8 *      DataPointer8   = (uint8 *)(FileHeader->SymAddress.Offset);
+    uint8 *      ioBuffer8      = (uint8 *)&MM_AppData.DumpBuffer[0];
+    uint32       SegmentSize    = MM_MAX_DUMP_DATA_SEG;
 
     while (BytesRemaining != 0)
     {
@@ -220,14 +220,14 @@ bool MM_DumpMem8ToFile(osal_id_t FileHandle, const char *FileName, const MM_Load
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_FillMem8(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
 {
-    uint32 i;
-    int32  PSP_Status     = CFE_PSP_SUCCESS;
-    uint32 BytesProcessed = 0;
-    uint32 BytesRemaining = CmdPtr->NumOfBytes;
-    uint8  FillPattern8   = (uint8)CmdPtr->FillPattern;
-    uint8 *DataPointer8   = (uint8 *)DestAddress;
-    uint32 SegmentSize    = MM_MAX_FILL_DATA_SEG;
-    bool   Result         = true;
+    uint32       i;
+    CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
+    uint32       BytesProcessed = 0;
+    uint32       BytesRemaining = CmdPtr->NumOfBytes;
+    uint8        FillPattern8   = (uint8)CmdPtr->FillPattern;
+    uint8 *      DataPointer8   = (uint8 *)DestAddress;
+    uint32       SegmentSize    = MM_MAX_FILL_DATA_SEG;
+    bool         Result         = true;
 
     while (BytesRemaining != 0)
     {

--- a/fsw/src/mm_utils.c
+++ b/fsw/src/mm_utils.c
@@ -298,11 +298,11 @@ bool MM_VerifyPeekPokeParams(cpuaddr Address, MM_MemType_t MemType, uint8 SizeIn
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool MM_VerifyLoadDumpParams(cpuaddr Address, MM_MemType_t MemType, uint32 SizeInBytes, uint8 VerifyType)
 {
-    bool   Valid = true;
-    int32  PSP_Status;
-    uint32 MaxSize     = 0;
-    uint32 PSP_MemType = 0;
-    char   MemTypeStr[MM_MAX_MEM_TYPE_STR_LEN];
+    bool         Valid = true;
+    CFE_Status_t PSP_Status;
+    uint32       MaxSize     = 0;
+    uint32       PSP_MemType = 0;
+    char         MemTypeStr[MM_MAX_MEM_TYPE_STR_LEN];
 
     if ((VerifyType != MM_VERIFY_LOAD) && (VerifyType != MM_VERIFY_DUMP) && (VerifyType != MM_VERIFY_EVENT) &&
         (VerifyType != MM_VERIFY_FILL) && (VerifyType != MM_VERIFY_WID))

--- a/unit-test/mm_app_tests.c
+++ b/unit-test/mm_app_tests.c
@@ -55,7 +55,8 @@ uint8 call_count_CFE_EVS_SendEvent;
  * Function Definitions
  */
 
-int32 MM_APP_TEST_CFE_SB_RcvMsgHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
+CFE_Status_t MM_APP_TEST_CFE_SB_RcvMsgHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                           const UT_StubContext_t *Context)
 {
     return CFE_SUCCESS;
 }
@@ -217,9 +218,9 @@ void MM_AppMain_Test_SBTimeout(void)
 
 void MM_AppInit_Test_Nominal(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "MM Initialized. Version %%d.%%d.%%d.%%d");
 
@@ -252,9 +253,9 @@ void MM_AppInit_Test_Nominal(void)
 
 void MM_AppInit_Test_EVSRegisterError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedSysLogString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "MM App: Error Registering For Event Services, RC = 0x%%08X\n");
@@ -287,9 +288,9 @@ void MM_AppInit_Test_EVSRegisterError(void)
 
 void MM_AppInit_Test_SBCreatePipeError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Creating SB Pipe, RC = 0x%%08X");
 
@@ -321,9 +322,9 @@ void MM_AppInit_Test_SBCreatePipeError(void)
 
 void MM_AppInit_Test_SBSubscribeHKError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Subscribing to HK Request, RC = 0x%%08X");
 
@@ -355,9 +356,9 @@ void MM_AppInit_Test_SBSubscribeHKError(void)
 
 void MM_AppInit_Test_SBSubscribeMMError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Subscribing to MM Command, RC = 0x%%08X");
 

--- a/unit-test/stubs/mm_app_stubs.c
+++ b/unit-test/stubs/mm_app_stubs.c
@@ -50,7 +50,7 @@ void MM_AppMain(void)
     UT_DEFAULT_IMPL(MM_AppMain);
 }
 
-int32 MM_AppInit(void)
+CFE_Status_t MM_AppInit(void)
 {
     return UT_DEFAULT_IMPL(MM_AppInit);
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #72
  - suitable `int32` return codes converted over to `CFE_Status_t`
  - `int32` `status`/`return` variables holding cFE return codes converted to `CFE_Status_t`

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior.
`CFE_Status_t` is more expressive and improves consistency with cFE/cFS.

**Contributor Info**
Avi Weiss @thnkslprpt