### PR TITLE
Fix #80, cmd and tlm messages use payload sub-structure

### DIFF
--- a/fsw/inc/mm_msg.h
+++ b/fsw/inc/mm_msg.h
@@ -69,6 +69,114 @@ typedef struct
 } MM_SymAddr_t;
 
 /**
+ *  \brief Memory Peek Command Payload
+ */
+typedef struct
+{
+    size_t       DataSize;      /**< \brief Size of the data to be read     */
+    MM_MemType_t MemType;       /**< \brief Memory type to peek data from   */
+    MM_SymAddr_t SrcSymAddress; /**< \brief Symbolic source peek address    */
+} MM_PeekCmd_Payload_t;
+
+/**
+ *  \brief Memory Poke Command Payload
+ */
+typedef struct
+{
+    size_t       DataSize;       /**< \brief Size of the data to be written     */
+    MM_MemType_t MemType;        /**< \brief Memory type to poke data to        */
+    uint32       Data;           /**< \brief Data to be written                 */
+    uint8        Padding2[4];    /**< \brief Structure padding                  */
+    MM_SymAddr_t DestSymAddress; /**< \brief Symbolic destination poke address  */
+} MM_PokeCmd_Payload_t;
+
+/**
+ *  \brief Memory Load With Interrupts Disabled Command Payload
+ */
+typedef struct
+{
+    uint8        NumOfBytes;                             /**< \brief Number of bytes to be loaded       */
+    uint8        Padding[3];                             /**< \brief Structure padding                  */
+    uint32       Crc;                                    /**< \brief Data check value                   */
+    MM_SymAddr_t DestSymAddress;                         /**< \brief Symbolic destination load address  */
+    uint8        DataArray[MM_MAX_UNINTERRUPTIBLE_DATA]; /**< \brief Data to be loaded           */
+} MM_LoadMemWIDCmd_Payload_t;
+
+/**
+ *  \brief Dump Memory In Event Message Command Payload
+ */
+typedef struct
+{
+    MM_MemType_t MemType;       /**< \brief Memory dump type             */
+    uint8        NumOfBytes;    /**< \brief Number of bytes to be dumped */
+    uint8        Padding[3];    /**< \brief Structure padding            */
+    MM_SymAddr_t SrcSymAddress; /**< \brief Symbolic source address      */
+} MM_DumpInEventCmd_Payload_t;
+
+/**
+ *  \brief Memory Load From File Command Payload
+ */
+typedef struct
+{
+    char FileName[OS_MAX_PATH_LEN]; /**< \brief Name of memory load file */
+} MM_LoadMemFromFileCmd_Payload_t;
+
+/**
+ *  \brief Memory Dump To File Command Payload
+ */
+typedef struct
+{
+    MM_MemType_t MemType;                   /**< \brief Memory dump type */
+    uint32       NumOfBytes;                /**< \brief Number of bytes to be dumped */
+    MM_SymAddr_t SrcSymAddress;             /**< \brief Symbol plus optional offset  */
+    char         FileName[OS_MAX_PATH_LEN]; /**< \brief Name of memory dump file */
+} MM_DumpMemToFileCmd_Payload_t;
+
+/**
+ *  \brief Memory Fill Command Payload
+ */
+typedef struct
+{
+    MM_MemType_t MemType;        /**< \brief Memory type                  */
+    uint32       NumOfBytes;     /**< \brief Number of bytes to fill      */
+    uint32       FillPattern;    /**< \brief Fill pattern to use          */
+    uint8        Padding[4];     /**< \brief Structure padding            */
+    MM_SymAddr_t DestSymAddress; /**< \brief Symbol plus optional offset  */
+} MM_FillMemCmd_Payload_t;
+
+/**
+ *  \brief Symbol Table Lookup Command Payload
+ */
+typedef struct
+{
+    char SymName[OS_MAX_SYM_LEN]; /**< \brief Symbol name string           */
+} MM_LookupSymCmd_Payload_t;
+
+/**
+ *  \brief Save Symbol Table To File Command Payload
+ */
+typedef struct
+{
+    char FileName[OS_MAX_PATH_LEN]; /**< \brief Name of symbol dump file */
+} MM_SymTblToFileCmd_Payload_t;
+
+/**
+ *  \brief EEPROM Write Enable Command Payload
+ */
+typedef struct
+{
+    uint32 Bank; /**< \brief EEPROM bank number to write-enable */
+} MM_EepromWriteEnaCmd_Payload_t;
+
+/**
+ *  \brief EEPROM Write Disable Command Payload
+ */
+typedef struct
+{
+    uint32 Bank; /**< \brief EEPROM bank number to write-disable */
+} MM_EepromWriteDisCmd_Payload_t;
+
+/**
  *  \brief No Arguments Command
  *
  *  For command details see #MM_NOOP_CC, #MM_RESET_CC
@@ -86,10 +194,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    size_t       DataSize;      /**< \brief Size of the data to be read     */
-    MM_MemType_t MemType;       /**< \brief Memory type to peek data from   */
-    MM_SymAddr_t SrcSymAddress; /**< \brief Symbolic source peek address    */
+    MM_PeekCmd_Payload_t    Payload;
 } MM_PeekCmd_t;
 
 /**
@@ -100,12 +205,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    size_t       DataSize;       /**< \brief Size of the data to be written     */
-    MM_MemType_t MemType;        /**< \brief Memory type to poke data to        */
-    uint32       Data;           /**< \brief Data to be written                 */
-    uint8        Padding2[4];    /**< \brief Structure padding                  */
-    MM_SymAddr_t DestSymAddress; /**< \brief Symbolic destination poke address  */
+    MM_PokeCmd_Payload_t    Payload;
 } MM_PokeCmd_t;
 
 /**
@@ -115,13 +215,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    uint8        NumOfBytes;                             /**< \brief Number of bytes to be loaded       */
-    uint8        Padding[3];                             /**< \brief Structure padding                  */
-    uint32       Crc;                                    /**< \brief Data check value                   */
-    MM_SymAddr_t DestSymAddress;                         /**< \brief Symbolic destination load address  */
-    uint8        DataArray[MM_MAX_UNINTERRUPTIBLE_DATA]; /**< \brief Data to be loaded           */
+    CFE_MSG_CommandHeader_t    CmdHeader; /**< \brief Command header */
+    MM_LoadMemWIDCmd_Payload_t Payload;
 } MM_LoadMemWIDCmd_t;
 
 /**
@@ -131,12 +226,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    MM_MemType_t MemType;       /**< \brief Memory dump type             */
-    uint8        NumOfBytes;    /**< \brief Number of bytes to be dumped */
-    uint8        Padding[3];    /**< \brief Structure padding            */
-    MM_SymAddr_t SrcSymAddress; /**< \brief Symbolic source address      */
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    MM_DumpInEventCmd_Payload_t Payload;
 } MM_DumpInEventCmd_t;
 
 /**
@@ -146,9 +237,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    char FileName[OS_MAX_PATH_LEN]; /**< \brief Name of memory load file */
+    CFE_MSG_CommandHeader_t         CmdHeader; /**< \brief Command header */
+    MM_LoadMemFromFileCmd_Payload_t Payload;
 } MM_LoadMemFromFileCmd_t;
 
 /**
@@ -158,12 +248,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    MM_MemType_t MemType;                   /**< \brief Memory dump type */
-    uint32       NumOfBytes;                /**< \brief Number of bytes to be dumped */
-    MM_SymAddr_t SrcSymAddress;             /**< \brief Symbol plus optional offset  */
-    char         FileName[OS_MAX_PATH_LEN]; /**< \brief Name of memory dump file */
+    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    MM_DumpMemToFileCmd_Payload_t Payload;
 } MM_DumpMemToFileCmd_t;
 
 /**
@@ -174,12 +260,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    MM_MemType_t MemType;        /**< \brief Memory type                  */
-    uint32       NumOfBytes;     /**< \brief Number of bytes to fill      */
-    uint32       FillPattern;    /**< \brief Fill pattern to use          */
-    uint8        Padding[4];     /**< \brief Structure padding            */
-    MM_SymAddr_t DestSymAddress; /**< \brief Symbol plus optional offset  */
+    MM_FillMemCmd_Payload_t Payload;
 } MM_FillMemCmd_t;
 
 /**
@@ -189,9 +270,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    char SymName[OS_MAX_SYM_LEN]; /**< \brief Symbol name string           */
+    CFE_MSG_CommandHeader_t   CmdHeader; /**< \brief Command header */
+    MM_LookupSymCmd_Payload_t Payload;
 } MM_LookupSymCmd_t;
 
 /**
@@ -201,9 +281,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    char FileName[OS_MAX_PATH_LEN]; /**< \brief Name of symbol dump file */
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    MM_SymTblToFileCmd_Payload_t Payload;
 } MM_SymTblToFileCmd_t;
 
 /**
@@ -213,9 +292,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    uint32 Bank; /**< \brief EEPROM bank number to write-enable */
+    CFE_MSG_CommandHeader_t        CmdHeader; /**< \brief Command header */
+    MM_EepromWriteEnaCmd_Payload_t Payload;
 } MM_EepromWriteEnaCmd_t;
 
 /**
@@ -225,9 +303,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
-    uint32 Bank; /**< \brief EEPROM bank number to write-disable */
+    CFE_MSG_CommandHeader_t        CmdHeader; /**< \brief Command header */
+    MM_EepromWriteDisCmd_Payload_t Payload;
 } MM_EepromWriteDisCmd_t;
 
 /**\}*/
@@ -238,12 +315,10 @@ typedef struct
  */
 
 /**
- *  \brief Housekeeping Packet Structure
+ *  \brief Housekeeping Packet Payload Structure
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry header */
-
     uint8        CmdCounter;                /**< \brief MM Application Command Counter */
     uint8        ErrCounter;                /**< \brief MM Application Command Error Counter */
     uint8        LastAction;                /**< \brief Last command action executed */
@@ -253,6 +328,15 @@ typedef struct
     uint32       DataValue;                 /**< \brief Last command data (fill pattern or peek/poke value) */
     size_t       BytesProcessed;            /**< \brief Bytes processed for last command */
     char         FileName[OS_MAX_PATH_LEN]; /**< \brief Name of the data file used for last command, where applicable */
+} MM_HkPacket_Payload_t;
+
+/**
+ *  \brief Housekeeping Packet Structure
+ */
+typedef struct
+{
+    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry header */
+    MM_HkPacket_Payload_t     Payload;
 } MM_HkPacket_t;
 
 /**\}*/

--- a/fsw/inc/mm_msgdefs.h
+++ b/fsw/inc/mm_msgdefs.h
@@ -89,7 +89,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
  *       - The #MM_NOOP_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -98,7 +98,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *
  *  \par Criticality
@@ -120,8 +120,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will be cleared
- *       - #MM_HkPacket_t.ErrCounter will be cleared
+ *       - #MM_HkPacket_Payload_t.CmdCounter will be cleared
+ *       - #MM_HkPacket_Payload_t.ErrCounter will be cleared
  *       - The #MM_RESET_INF_EID informational event message will be
  *         generated when the command is executed
  *
@@ -130,7 +130,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *
  *  \par Criticality
@@ -152,11 +152,11 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_PEEK
- *       - #MM_HkPacket_t.MemType will be set to the commanded memory type
- *       - #MM_HkPacket_t.Address will be set to the fully resolved destination memory address
- *       - #MM_HkPacket_t.BytesProcessed will be set to the byte size of the peek operation (1, 2, or 4)
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_PEEK
+ *       - #MM_HkPacket_Payload_t.MemType will be set to the commanded memory type
+ *       - #MM_HkPacket_Payload_t.Address will be set to the fully resolved destination memory address
+ *       - #MM_HkPacket_Payload_t.BytesProcessed will be set to the byte size of the peek operation (1, 2, or 4)
  *       - The #MM_PEEK_BYTE_INF_EID informational event message will
  *         be generated with the peek data if the data size was 8 bits
  *       - The #MM_PEEK_WORD_INF_EID informational event message will
@@ -174,7 +174,7 @@
  *       - The address and data size are not properly aligned
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_DATA_SIZE_BITS_ERR_EID
@@ -209,11 +209,11 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_POKE
- *       - #MM_HkPacket_t.MemType will be set to the commanded memory type
- *       - #MM_HkPacket_t.Address will be set to the fully resolved source memory address
- *       - #MM_HkPacket_t.BytesProcessed will be set to the byte size of the poke operation (1, 2, or 4)
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_POKE
+ *       - #MM_HkPacket_Payload_t.MemType will be set to the commanded memory type
+ *       - #MM_HkPacket_Payload_t.Address will be set to the fully resolved source memory address
+ *       - #MM_HkPacket_Payload_t.BytesProcessed will be set to the byte size of the poke operation (1, 2, or 4)
  *       - The #MM_POKE_BYTE_INF_EID informational event message will
  *         be generated if the data size was 8 bits
  *       - The #MM_POKE_WORD_INF_EID informational event message will
@@ -232,7 +232,7 @@
  *       - An EEPROM write error occured
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_DATA_SIZE_BITS_ERR_EID
@@ -276,10 +276,10 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_LOAD_WID
- *       - #MM_HkPacket_t.Address will be set to the fully resolved destination memory address
- *       - #MM_HkPacket_t.BytesProcessed will be set to the number of bytes loaded
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_LOAD_WID
+ *       - #MM_HkPacket_Payload_t.Address will be set to the fully resolved destination memory address
+ *       - #MM_HkPacket_Payload_t.BytesProcessed will be set to the number of bytes loaded
  *       - The #MM_LOAD_WID_INF_EID information event message will be
  *         generated when the command is executed
  *
@@ -292,7 +292,7 @@
  *       - Invalid data size specified in command message
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_LOAD_WID_CRC_ERR_EID
@@ -329,12 +329,12 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_LOAD_FROM_FILE
- *       - #MM_HkPacket_t.MemType will be set to the commanded memory type
- *       - #MM_HkPacket_t.Address will be set to the fully resolved destination memory address
- *       - #MM_HkPacket_t.BytesProcessed will be set to the number of bytes loaded
- *       - #MM_HkPacket_t.FileName will be set to the load file name
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_LOAD_FROM_FILE
+ *       - #MM_HkPacket_Payload_t.MemType will be set to the commanded memory type
+ *       - #MM_HkPacket_Payload_t.Address will be set to the fully resolved destination memory address
+ *       - #MM_HkPacket_Payload_t.BytesProcessed will be set to the number of bytes loaded
+ *       - #MM_HkPacket_Payload_t.FileName will be set to the load file name
  *       - The #MM_LD_MEM_FILE_INF_EID informational event message will
  *         be generated
  *
@@ -356,7 +356,7 @@
  *       - The specified memory type is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_OS_OPEN_ERR_EID
  *       - Error specific event message #MM_OS_CLOSE_ERR_EID
@@ -403,12 +403,12 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_DUMP_TO_FILE
- *       - #MM_HkPacket_t.MemType will be set to the commanded memory type
- *       - #MM_HkPacket_t.Address will be set to the fully resolved source memory address
- *       - #MM_HkPacket_t.BytesProcessed will be set to the number of bytes dumped
- *       - #MM_HkPacket_t.FileName will be set to the dump file name
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_DUMP_TO_FILE
+ *       - #MM_HkPacket_Payload_t.MemType will be set to the commanded memory type
+ *       - #MM_HkPacket_Payload_t.Address will be set to the fully resolved source memory address
+ *       - #MM_HkPacket_Payload_t.BytesProcessed will be set to the number of bytes dumped
+ *       - #MM_HkPacket_Payload_t.FileName will be set to the dump file name
  *       - The #MM_DMP_MEM_FILE_INF_EID informational event message will
  *         be generated
  *
@@ -429,7 +429,7 @@
  *       - The specified memory type is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_OS_CREAT_ERR_EID
@@ -469,11 +469,11 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_DUMP_INEVENT
- *       - #MM_HkPacket_t.MemType will be set to the commanded memory type
- *       - #MM_HkPacket_t.Address will be set to the fully resolved source memory address
- *       - #MM_HkPacket_t.BytesProcessed will be set to the number of bytes dumped
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_DUMP_INEVENT
+ *       - #MM_HkPacket_Payload_t.MemType will be set to the commanded memory type
+ *       - #MM_HkPacket_Payload_t.Address will be set to the fully resolved source memory address
+ *       - #MM_HkPacket_Payload_t.BytesProcessed will be set to the number of bytes dumped
  *       - The #MM_DUMP_INEVENT_INF_EID informational event message will
  *         be generated with the dump data
  *
@@ -487,7 +487,7 @@
  *       - The specified memory type is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_OS_MEMVALIDATE_ERR_EID
@@ -522,12 +522,12 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_FILL
- *       - #MM_HkPacket_t.MemType will be set to the commanded memory type
- *       - #MM_HkPacket_t.Address will be set to the fully resolved destination memory address
- *       - #MM_HkPacket_t.DataValue will be set to the fill pattern used
- *       - #MM_HkPacket_t.BytesProcessed will be set to the number of bytes filled
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_FILL
+ *       - #MM_HkPacket_Payload_t.MemType will be set to the commanded memory type
+ *       - #MM_HkPacket_Payload_t.Address will be set to the fully resolved destination memory address
+ *       - #MM_HkPacket_Payload_t.DataValue will be set to the fill pattern used
+ *       - #MM_HkPacket_Payload_t.BytesProcessed will be set to the number of bytes filled
  *       - The #MM_FILL_INF_EID informational event message will
  *         be generated when the command is executed
  *
@@ -541,7 +541,7 @@
  *       - The specified memory type is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
  *       - Error specific event message #MM_OS_MEMVALIDATE_ERR_EID
@@ -580,9 +580,9 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_SYM_LOOKUP
- *       - #MM_HkPacket_t.Address will be set to the fully resolved memory address
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_SYM_LOOKUP
+ *       - #MM_HkPacket_Payload_t.Address will be set to the fully resolved memory address
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
@@ -591,7 +591,7 @@
  *       - A symbol name was specified that can't be resolved
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_SYMNAME_NUL_ERR_EID
  *       - Error specific event message #MM_SYMNAME_ERR_EID
@@ -616,9 +616,9 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_SYMTBL_SAVE
- *       - #MM_HkPacket_t.FileName will be set to the dump file name
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_SYMTBL_SAVE
+ *       - #MM_HkPacket_Payload_t.FileName will be set to the dump file name
  *       - The #MM_SYMTBL_TO_FILE_INF_EID informational event message will
  *         be generated when the command is executed
  *
@@ -629,7 +629,7 @@
  *       - The OSAL returns a status other than success to the command
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_SYMFILENAME_NUL_ERR_EID
  *       - Error specific event message #MM_SYMTBL_TO_FILE_FAIL_ERR_EID
@@ -656,8 +656,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_EEPROMWRITE_ENA
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_EEPROMWRITE_ENA
  *       - The #MM_EEPROM_WRITE_ENA_INF_EID informational event message will
  *         be generated when the command is executed
  *
@@ -667,7 +667,7 @@
  *       - Non-success return status from PSP write enable
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_EEPROM_WRITE_ENA_ERR_EID
  *
@@ -694,8 +694,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #MM_HkPacket_t.CmdCounter will increment
- *       - #MM_HkPacket_t.LastAction will be set to #MM_EEPROMWRITE_DIS
+ *       - #MM_HkPacket_Payload_t.CmdCounter will increment
+ *       - #MM_HkPacket_Payload_t.LastAction will be set to #MM_EEPROMWRITE_DIS
  *       - The #MM_EEPROM_WRITE_DIS_INF_EID informational event message will
  *         be generated when the command is executed
  *
@@ -705,7 +705,7 @@
  *       - Non-success return status from PSP write disable
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #MM_HkPacket_t.ErrCounter will increment
+ *       - #MM_HkPacket_Payload_t.ErrCounter will increment
  *       - Error specific event message #MM_LEN_ERR_EID
  *       - Error specific event message #MM_EEPROM_WRITE_DIS_ERR_EID
  *

--- a/fsw/src/mm_mem16.c
+++ b/fsw/src/mm_mem16.c
@@ -116,11 +116,11 @@ bool MM_LoadMem16FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
     if (BytesProcessed == FileHeader->NumOfBytes)
     {
         Valid                              = true;
-        MM_AppData.HkPacket.LastAction     = MM_LOAD_FROM_FILE;
-        MM_AppData.HkPacket.MemType        = MM_MEM16;
-        MM_AppData.HkPacket.Address        = DestAddress;
-        MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
-        strncpy(MM_AppData.HkPacket.FileName, FileName, OS_MAX_PATH_LEN);
+        MM_AppData.HkPacket.Payload.LastAction     = MM_LOAD_FROM_FILE;
+        MM_AppData.HkPacket.Payload.MemType        = MM_MEM16;
+        MM_AppData.HkPacket.Payload.Address        = DestAddress;
+        MM_AppData.HkPacket.Payload.BytesProcessed = BytesProcessed;
+        strncpy(MM_AppData.HkPacket.Payload.FileName, FileName, OS_MAX_PATH_LEN);
     }
 
     return Valid;
@@ -202,11 +202,11 @@ bool MM_DumpMem16ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
     if (Valid)
     {
         /* Update last action statistics */
-        MM_AppData.HkPacket.LastAction = MM_DUMP_TO_FILE;
-        MM_AppData.HkPacket.MemType    = MM_MEM16;
-        MM_AppData.HkPacket.Address    = FileHeader->SymAddress.Offset;
-        strncpy(MM_AppData.HkPacket.FileName, FileName, OS_MAX_PATH_LEN);
-        MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
+        MM_AppData.HkPacket.Payload.LastAction = MM_DUMP_TO_FILE;
+        MM_AppData.HkPacket.Payload.MemType    = MM_MEM16;
+        MM_AppData.HkPacket.Payload.Address    = FileHeader->SymAddress.Offset;
+        strncpy(MM_AppData.HkPacket.Payload.FileName, FileName, OS_MAX_PATH_LEN);
+        MM_AppData.HkPacket.Payload.BytesProcessed = BytesProcessed;
     }
 
     return Valid;
@@ -223,9 +223,9 @@ bool MM_FillMem16(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
     uint32       i;
     CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
     size_t       BytesProcessed = 0;
-    uint32       BytesRemaining = CmdPtr->NumOfBytes;
+    uint32       BytesRemaining = CmdPtr->Payload.NumOfBytes;
     uint32       NewBytesRemaining;
-    uint16       FillPattern16 = (uint16)CmdPtr->FillPattern;
+    uint16       FillPattern16 = (uint16)CmdPtr->Payload.FillPattern;
     uint16 *     DataPointer16 = (uint16 *)DestAddress;
     size_t       SegmentSize   = MM_MAX_FILL_DATA_SEG;
     bool         Result        = true;
@@ -284,13 +284,13 @@ bool MM_FillMem16(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
     }
 
     /* Update last action statistics */
-    if (BytesProcessed == CmdPtr->NumOfBytes)
+    if (BytesProcessed == CmdPtr->Payload.NumOfBytes)
     {
-        MM_AppData.HkPacket.LastAction     = MM_FILL;
-        MM_AppData.HkPacket.MemType        = MM_MEM16;
-        MM_AppData.HkPacket.Address        = DestAddress;
-        MM_AppData.HkPacket.DataValue      = (uint32)FillPattern16;
-        MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
+        MM_AppData.HkPacket.Payload.LastAction     = MM_FILL;
+        MM_AppData.HkPacket.Payload.MemType        = MM_MEM16;
+        MM_AppData.HkPacket.Payload.Address        = DestAddress;
+        MM_AppData.HkPacket.Payload.DataValue      = (uint32)FillPattern16;
+        MM_AppData.HkPacket.Payload.BytesProcessed = BytesProcessed;
     }
 
     return Result;

--- a/fsw/src/mm_mem32.c
+++ b/fsw/src/mm_mem32.c
@@ -116,11 +116,11 @@ bool MM_LoadMem32FromFile(osal_id_t FileHandle, const char *FileName, const MM_L
     if (BytesProcessed == FileHeader->NumOfBytes)
     {
         Valid                              = true;
-        MM_AppData.HkPacket.LastAction     = MM_LOAD_FROM_FILE;
-        MM_AppData.HkPacket.MemType        = MM_MEM32;
-        MM_AppData.HkPacket.Address        = DestAddress;
-        MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
-        strncpy(MM_AppData.HkPacket.FileName, FileName, OS_MAX_PATH_LEN);
+        MM_AppData.HkPacket.Payload.LastAction     = MM_LOAD_FROM_FILE;
+        MM_AppData.HkPacket.Payload.MemType        = MM_MEM32;
+        MM_AppData.HkPacket.Payload.Address        = DestAddress;
+        MM_AppData.HkPacket.Payload.BytesProcessed = BytesProcessed;
+        strncpy(MM_AppData.HkPacket.Payload.FileName, FileName, OS_MAX_PATH_LEN);
     }
 
     return Valid;
@@ -203,11 +203,11 @@ bool MM_DumpMem32ToFile(osal_id_t FileHandle, const char *FileName, const MM_Loa
     if (Valid)
     {
         /* Update last action statistics */
-        MM_AppData.HkPacket.LastAction = MM_DUMP_TO_FILE;
-        MM_AppData.HkPacket.MemType    = MM_MEM32;
-        MM_AppData.HkPacket.Address    = FileHeader->SymAddress.Offset;
-        strncpy(MM_AppData.HkPacket.FileName, FileName, OS_MAX_PATH_LEN);
-        MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
+        MM_AppData.HkPacket.Payload.LastAction = MM_DUMP_TO_FILE;
+        MM_AppData.HkPacket.Payload.MemType    = MM_MEM32;
+        MM_AppData.HkPacket.Payload.Address    = FileHeader->SymAddress.Offset;
+        strncpy(MM_AppData.HkPacket.Payload.FileName, FileName, OS_MAX_PATH_LEN);
+        MM_AppData.HkPacket.Payload.BytesProcessed = BytesProcessed;
     }
 
     return Valid;
@@ -224,9 +224,9 @@ bool MM_FillMem32(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
     uint32       i;
     CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
     size_t       BytesProcessed = 0;
-    uint32       BytesRemaining = CmdPtr->NumOfBytes;
+    uint32       BytesRemaining = CmdPtr->Payload.NumOfBytes;
     uint32       NewBytesRemaining;
-    uint32       FillPattern32 = CmdPtr->FillPattern;
+    uint32       FillPattern32 = CmdPtr->Payload.FillPattern;
     uint32 *     DataPointer32 = (uint32 *)(DestAddress);
     size_t       SegmentSize   = MM_MAX_FILL_DATA_SEG;
     bool         Result        = true;
@@ -285,13 +285,13 @@ bool MM_FillMem32(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
     }
 
     /* Update last action statistics */
-    if (BytesProcessed == CmdPtr->NumOfBytes)
+    if (BytesProcessed == CmdPtr->Payload.NumOfBytes)
     {
-        MM_AppData.HkPacket.LastAction     = MM_FILL;
-        MM_AppData.HkPacket.MemType        = MM_MEM32;
-        MM_AppData.HkPacket.Address        = DestAddress;
-        MM_AppData.HkPacket.DataValue      = FillPattern32;
-        MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
+        MM_AppData.HkPacket.Payload.LastAction     = MM_FILL;
+        MM_AppData.HkPacket.Payload.MemType        = MM_MEM32;
+        MM_AppData.HkPacket.Payload.Address        = DestAddress;
+        MM_AppData.HkPacket.Payload.DataValue      = FillPattern32;
+        MM_AppData.HkPacket.Payload.BytesProcessed = BytesProcessed;
     }
 
     return Result;

--- a/fsw/src/mm_mem8.c
+++ b/fsw/src/mm_mem8.c
@@ -116,11 +116,11 @@ bool MM_LoadMem8FromFile(osal_id_t FileHandle, const char *FileName, const MM_Lo
     if (BytesProcessed == FileHeader->NumOfBytes)
     {
         Valid                              = true;
-        MM_AppData.HkPacket.LastAction     = MM_LOAD_FROM_FILE;
-        MM_AppData.HkPacket.MemType        = MM_MEM8;
-        MM_AppData.HkPacket.Address        = DestAddress;
-        MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
-        strncpy(MM_AppData.HkPacket.FileName, FileName, OS_MAX_PATH_LEN);
+        MM_AppData.HkPacket.Payload.LastAction     = MM_LOAD_FROM_FILE;
+        MM_AppData.HkPacket.Payload.MemType        = MM_MEM8;
+        MM_AppData.HkPacket.Payload.Address        = DestAddress;
+        MM_AppData.HkPacket.Payload.BytesProcessed = BytesProcessed;
+        strncpy(MM_AppData.HkPacket.Payload.FileName, FileName, OS_MAX_PATH_LEN);
     }
 
     return Valid;
@@ -202,11 +202,11 @@ bool MM_DumpMem8ToFile(osal_id_t FileHandle, const char *FileName, const MM_Load
     if (Valid)
     {
         /* Update last action statistics */
-        MM_AppData.HkPacket.LastAction = MM_DUMP_TO_FILE;
-        MM_AppData.HkPacket.MemType    = MM_MEM8;
-        MM_AppData.HkPacket.Address    = FileHeader->SymAddress.Offset;
-        strncpy(MM_AppData.HkPacket.FileName, FileName, OS_MAX_PATH_LEN);
-        MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
+        MM_AppData.HkPacket.Payload.LastAction = MM_DUMP_TO_FILE;
+        MM_AppData.HkPacket.Payload.MemType    = MM_MEM8;
+        MM_AppData.HkPacket.Payload.Address    = FileHeader->SymAddress.Offset;
+        strncpy(MM_AppData.HkPacket.Payload.FileName, FileName, OS_MAX_PATH_LEN);
+        MM_AppData.HkPacket.Payload.BytesProcessed = BytesProcessed;
     }
 
     return Valid;
@@ -223,8 +223,8 @@ bool MM_FillMem8(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
     uint32       i;
     CFE_Status_t PSP_Status     = CFE_PSP_SUCCESS;
     size_t       BytesProcessed = 0;
-    uint32       BytesRemaining = CmdPtr->NumOfBytes;
-    uint8        FillPattern8   = (uint8)CmdPtr->FillPattern;
+    uint32       BytesRemaining = CmdPtr->Payload.NumOfBytes;
+    uint8        FillPattern8   = (uint8)CmdPtr->Payload.FillPattern;
     uint8 *      DataPointer8   = (uint8 *)DestAddress;
     size_t       SegmentSize    = MM_MAX_FILL_DATA_SEG;
     bool         Result         = true;
@@ -273,13 +273,13 @@ bool MM_FillMem8(cpuaddr DestAddress, const MM_FillMemCmd_t *CmdPtr)
     }
 
     /* Update last action statistics */
-    if (BytesProcessed == CmdPtr->NumOfBytes)
+    if (BytesProcessed == CmdPtr->Payload.NumOfBytes)
     {
-        MM_AppData.HkPacket.LastAction     = MM_FILL;
-        MM_AppData.HkPacket.MemType        = MM_MEM8;
-        MM_AppData.HkPacket.Address        = DestAddress;
-        MM_AppData.HkPacket.DataValue      = (uint32)FillPattern8;
-        MM_AppData.HkPacket.BytesProcessed = BytesProcessed;
+        MM_AppData.HkPacket.Payload.LastAction     = MM_FILL;
+        MM_AppData.HkPacket.Payload.MemType        = MM_MEM8;
+        MM_AppData.HkPacket.Payload.Address        = DestAddress;
+        MM_AppData.HkPacket.Payload.DataValue      = (uint32)FillPattern8;
+        MM_AppData.HkPacket.Payload.BytesProcessed = BytesProcessed;
     }
 
     return Result;

--- a/fsw/src/mm_utils.c
+++ b/fsw/src/mm_utils.c
@@ -51,12 +51,12 @@ extern MM_AppData_t MM_AppData;
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void MM_ResetHk(void)
 {
-    MM_AppData.HkPacket.LastAction     = MM_NOACTION;
-    MM_AppData.HkPacket.MemType        = MM_NOMEMTYPE;
-    MM_AppData.HkPacket.Address        = MM_CLEAR_ADDR;
-    MM_AppData.HkPacket.DataValue      = MM_CLEAR_PATTERN;
-    MM_AppData.HkPacket.BytesProcessed = 0;
-    MM_AppData.HkPacket.FileName[0]    = MM_CLEAR_FNAME;
+    MM_AppData.HkPacket.Payload.LastAction     = MM_NOACTION;
+    MM_AppData.HkPacket.Payload.MemType        = MM_NOMEMTYPE;
+    MM_AppData.HkPacket.Payload.Address        = MM_CLEAR_ADDR;
+    MM_AppData.HkPacket.Payload.DataValue      = MM_CLEAR_PATTERN;
+    MM_AppData.HkPacket.Payload.BytesProcessed = 0;
+    MM_AppData.HkPacket.Payload.FileName[0]    = MM_CLEAR_FNAME;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/unit-test/mm_app_tests.c
+++ b/unit-test/mm_app_tests.c
@@ -64,7 +64,7 @@ CFE_Status_t MM_APP_TEST_CFE_SB_RcvMsgHook(void *UserObj, int32 StubRetcode, uin
 int32 MM_APP_TEST_CFE_ES_ExitAppHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                      const UT_StubContext_t *Context)
 {
-    MM_AppData.HkPacket.CmdCounter++;
+    MM_AppData.HkPacket.Payload.CmdCounter++;
 
     return 0;
 }
@@ -97,8 +97,8 @@ void MM_AppMain_Test_Nominal(void)
     MM_AppMain();
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     /* Generates 1 event message we don't care about in this test */
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -163,15 +163,15 @@ void MM_AppMain_Test_SBError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
 
-    /* Used to verify completion of MM_AppMain by incrementing MM_AppData.HkPacket.CmdCounter. */
+    /* Used to verify completion of MM_AppMain by incrementing MM_AppData.HkPacket.Payload.CmdCounter. */
     UT_SetHookFunction(UT_KEY(CFE_ES_ExitApp), MM_APP_TEST_CFE_ES_ExitAppHook, NULL);
 
     /* Execute the function being tested */
     MM_AppMain();
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, MM_PIPE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
@@ -202,7 +202,7 @@ void MM_AppMain_Test_SBTimeout(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
 
-    /* Used to verify completion of MM_AppMain by incrementing MM_AppData.HkPacket.CmdCounter. */
+    /* Used to verify completion of MM_AppMain by incrementing MM_AppData.HkPacket.Payload.CmdCounter. */
     UT_SetHookFunction(UT_KEY(CFE_ES_ExitApp), MM_APP_TEST_CFE_ES_ExitAppHook, NULL);
 
     /* Execute the function being tested */
@@ -235,8 +235,8 @@ void MM_AppInit_Test_Nominal(void)
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
     UtAssert_True(MM_AppData.RunStatus == CFE_ES_RunStatus_APP_RUN, "MM_AppData.RunStatus == CFE_ES_RunStatus_APP_RUN");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -274,8 +274,8 @@ void MM_AppInit_Test_EVSRegisterError(void)
     UtAssert_True(Result == -1, "Result == -1");
 
     UtAssert_True(MM_AppData.RunStatus == CFE_ES_RunStatus_APP_RUN, "MM_AppData.RunStatus == CFE_ES_RunStatus_APP_RUN");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -308,8 +308,8 @@ void MM_AppInit_Test_SBCreatePipeError(void)
     UtAssert_True(Result == -1, "Result == -1");
 
     UtAssert_True(MM_AppData.RunStatus == CFE_ES_RunStatus_APP_RUN, "MM_AppData.RunStatus == CFE_ES_RunStatus_APP_RUN");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -342,8 +342,8 @@ void MM_AppInit_Test_SBSubscribeHKError(void)
     UtAssert_True(Result == -1, "Result == -1");
 
     UtAssert_True(MM_AppData.RunStatus == CFE_ES_RunStatus_APP_RUN, "MM_AppData.RunStatus == CFE_ES_RunStatus_APP_RUN");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -376,8 +376,8 @@ void MM_AppInit_Test_SBSubscribeMMError(void)
     UtAssert_True(Result == -1, "Result == -1");
 
     UtAssert_True(MM_AppData.RunStatus == CFE_ES_RunStatus_APP_RUN, "MM_AppData.RunStatus == CFE_ES_RunStatus_APP_RUN");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -401,8 +401,8 @@ void MM_AppPipe_Test_SendHK(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -430,11 +430,11 @@ void MM_AppPipe_Test_NoopSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_NOOP, "MM_AppData.HkPacket.LastAction == MM_NOOP");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_NOOP, "MM_AppData.HkPacket.Payload.LastAction == MM_NOOP");
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
-    /* Note: this event message is generated in subfunction MM_NoopCmd.  It is checked here to verify that the
+    /* Note: this event message is generated in subfunction MM_NoopCmd.Payload.  It is checked here to verify that the
      * subfunction has been reached. */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_NOOP_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -468,8 +468,8 @@ void MM_AppPipe_Test_NoopFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -497,11 +497,11 @@ void MM_AppPipe_Test_ResetSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_RESET, "MM_AppData.HkPacket.LastAction == MM_RESET");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_RESET, "MM_AppData.HkPacket.Payload.LastAction == MM_RESET");
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
-    /* Note: this event message is generated in subfunction MM_ResetCmd.  It is checked here to verify that the
+    /* Note: this event message is generated in subfunction MM_ResetCmd.Payload.  It is checked here to verify that the
      * subfunction has been reached. */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_RESET_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -535,8 +535,8 @@ void MM_AppPipe_Test_ResetFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
@@ -557,8 +557,8 @@ void MM_AppPipe_Test_PeekSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     call_count_MM_PeekCmd = UT_GetStubCount(UT_KEY(MM_PeekCmd));
     UtAssert_INT32_EQ(call_count_MM_PeekCmd, 1);
@@ -579,8 +579,8 @@ void MM_AppPipe_Test_PeekFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     call_count_MM_PeekCmd = UT_GetStubCount(UT_KEY(MM_PeekCmd));
     UtAssert_INT32_EQ(call_count_MM_PeekCmd, 1);
@@ -600,8 +600,8 @@ void MM_AppPipe_Test_PokeSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     uint8 call_count_MM_PokeCmd = 0;
     call_count_MM_PokeCmd       = UT_GetStubCount(UT_KEY(MM_PokeCmd));
@@ -622,8 +622,8 @@ void MM_AppPipe_Test_PokeFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     uint8 call_count_MM_PokeCmd = 0;
     call_count_MM_PokeCmd       = UT_GetStubCount(UT_KEY(MM_PokeCmd));
@@ -644,8 +644,8 @@ void MM_AppPipe_Test_LoadMemWIDSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     uint8 call_count_MM_LoadMemWID = 0;
     call_count_MM_LoadMemWID       = UT_GetStubCount(UT_KEY(MM_LoadMemWIDCmd));
@@ -666,8 +666,8 @@ void MM_AppPipe_Test_LoadMemWIDFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     uint8 call_count_MM_LoadMemWID = 0;
     call_count_MM_LoadMemWID       = UT_GetStubCount(UT_KEY(MM_LoadMemWIDCmd));
@@ -688,8 +688,8 @@ void MM_AppPipe_Test_LoadMemFromFileSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     uint8 call_count_MM_LoadMemFromFile = 0;
     call_count_MM_LoadMemFromFile       = UT_GetStubCount(UT_KEY(MM_LoadMemFromFileCmd));
@@ -710,8 +710,8 @@ void MM_AppPipe_Test_LoadMemFromFileFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     uint8 call_count_MM_LoadMemFromFile = 0;
     call_count_MM_LoadMemFromFile       = UT_GetStubCount(UT_KEY(MM_LoadMemFromFileCmd));
@@ -732,8 +732,8 @@ void MM_AppPipe_Test_DumpMemToFileSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     uint8 call_count_MM_DumpMemToFile = 0;
     call_count_MM_DumpMemToFile       = UT_GetStubCount(UT_KEY(MM_DumpMemToFileCmd));
@@ -754,8 +754,8 @@ void MM_AppPipe_Test_DumpMemToFileFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     uint8 call_count_MM_DumpMemToFile = 0;
     call_count_MM_DumpMemToFile       = UT_GetStubCount(UT_KEY(MM_DumpMemToFileCmd));
@@ -776,8 +776,8 @@ void MM_AppPipe_Test_DumpInEventSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     uint8 call_count_MM_DumpInEvent = 0;
     call_count_MM_DumpInEvent       = UT_GetStubCount(UT_KEY(MM_DumpInEventCmd));
@@ -798,8 +798,8 @@ void MM_AppPipe_Test_DumpInEventFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     uint8 call_count_MM_DumpInEvent = 0;
     call_count_MM_DumpInEvent       = UT_GetStubCount(UT_KEY(MM_DumpInEventCmd));
@@ -820,8 +820,8 @@ void MM_AppPipe_Test_FillMemSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     uint8 call_count_MM_FillMem = 0;
     call_count_MM_FillMem       = UT_GetStubCount(UT_KEY(MM_FillMemCmd));
@@ -842,8 +842,8 @@ void MM_AppPipe_Test_FillMemFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     uint8 call_count_MM_FillMem = 0;
     call_count_MM_FillMem       = UT_GetStubCount(UT_KEY(MM_FillMemCmd));
@@ -861,7 +861,7 @@ void MM_AppPipe_Test_LookupSymbolSuccess(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    strncpy(UT_CmdBuf.LookupSymCmd.SymName, "name", sizeof(UT_CmdBuf.LookupSymCmd.SymName) - 1);
+    strncpy(UT_CmdBuf.LookupSymCmd.Payload.SymName, "name", sizeof(UT_CmdBuf.LookupSymCmd.Payload.SymName) - 1);
     UT_SetDataBuffer(UT_KEY(OS_SymbolLookup), &ResolvedAddr, sizeof(ResolvedAddr), false);
 
     /* ignore dummy message length check */
@@ -871,10 +871,10 @@ void MM_AppPipe_Test_LookupSymbolSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
-    /* Generates 1 event message in subfunction MM_LookupSymbolCmd.  Event message count = 1 verifies that the
+    /* Generates 1 event message in subfunction MM_LookupSymbolCmd.Payload.  Event message count = 1 verifies that the
      * subfunction has been reached. */
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
@@ -898,8 +898,8 @@ void MM_AppPipe_Test_LookupSymbolFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -916,7 +916,7 @@ void MM_AppPipe_Test_SymTblToFileSuccess(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    strncpy(UT_CmdBuf.SymTblToFileCmd.FileName, "name", sizeof(UT_CmdBuf.SymTblToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.SymTblToFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.SymTblToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy condition "OS_Status == OS_SUCCESS" */
     UT_SetDeferredRetcode(UT_KEY(OS_SymbolTableDump), 1, CFE_SUCCESS);
@@ -928,10 +928,10 @@ void MM_AppPipe_Test_SymTblToFileSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
-    /* Generates 1 event message in subfunction MM_SymTblToFileCmd.  Event message count = 1 verifies that the
+    /* Generates 1 event message in subfunction MM_SymTblToFileCmd.Payload.  Event message count = 1 verifies that the
      * subfunction has been reached. */
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
@@ -955,10 +955,10 @@ void MM_AppPipe_Test_SymTblToFileFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
-    /* Generates 1 event message in subfunction MM_SymTblToFileCmd.  Event message count = 1 verifies that the
+    /* Generates 1 event message in subfunction MM_SymTblToFileCmd.Payload.  Event message count = 1 verifies that the
      * subfunction has been reached. */
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -982,10 +982,10 @@ void MM_AppPipe_Test_EnableEepromWriteSuccess(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
-    /* Generates 1 event message in subfunction MM_EepromWriteEnaCmd.  Event message count = 1 verifies that the
+    /* Generates 1 event message in subfunction MM_EepromWriteEnaCmd.Payload.  Event message count = 1 verifies that the
      * subfunction has been reached. */
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
@@ -1009,8 +1009,8 @@ void MM_AppPipe_Test_EnableEepromWriteFail(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -1035,10 +1035,10 @@ void MM_AppPipe_Test_DisableEepromWriteSuccess(void)
 
     /* Verify results */
 
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 1);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
-    /* Generates 1 event message in subfunction MM_EepromWriteDisCmd.  Event message count = 1 verifies that the
+    /* Generates 1 event message in subfunction MM_EepromWriteDisCmd.Payload.  Event message count = 1 verifies that the
      * subfunction has been reached. */
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
@@ -1063,8 +1063,8 @@ void MM_AppPipe_Test_DisableEepromWriteFail(void)
 
     /* Verify results */
 
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -1093,8 +1093,8 @@ void MM_AppPipe_Test_InvalidCommandCode(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_CC1_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -1131,8 +1131,8 @@ void MM_AppPipe_Test_InvalidCommandPipeMessageID(void)
     MM_AppPipe(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 1);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_MID_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -1157,15 +1157,15 @@ void MM_HousekeepingCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    MM_AppData.HkPacket.CmdCounter     = 1;
-    MM_AppData.HkPacket.ErrCounter     = 2;
-    MM_AppData.HkPacket.LastAction     = 3;
-    MM_AppData.HkPacket.MemType        = 4;
-    MM_AppData.HkPacket.Address        = 5;
-    MM_AppData.HkPacket.DataValue      = 6;
-    MM_AppData.HkPacket.BytesProcessed = 7;
+    MM_AppData.HkPacket.Payload.CmdCounter     = 1;
+    MM_AppData.HkPacket.Payload.ErrCounter     = 2;
+    MM_AppData.HkPacket.Payload.LastAction     = 3;
+    MM_AppData.HkPacket.Payload.MemType        = 4;
+    MM_AppData.HkPacket.Payload.Address        = 5;
+    MM_AppData.HkPacket.Payload.DataValue      = 6;
+    MM_AppData.HkPacket.Payload.BytesProcessed = 7;
 
-    strncpy(MM_AppData.HkPacket.FileName, "name", sizeof(MM_AppData.HkPacket.FileName) - 1);
+    strncpy(MM_AppData.HkPacket.Payload.FileName, "name", sizeof(MM_AppData.HkPacket.Payload.FileName) - 1);
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -1174,16 +1174,16 @@ void MM_HousekeepingCmd_Test(void)
     MM_HousekeepingCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(MM_AppData.HkPacket.CmdCounter == 1, "MM_AppData.HkPacket.CmdCounter == 1");
-    UtAssert_True(MM_AppData.HkPacket.ErrCounter == 2, "MM_AppData.HkPacket.ErrCounter == 2");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == 3, "MM_AppData.HkPacket.LastAction == 3");
-    UtAssert_True(MM_AppData.HkPacket.MemType == 4, "MM_AppData.HkPacket.MemType == 4");
-    UtAssert_True(MM_AppData.HkPacket.Address == 5, "MM_AppData.HkPacket.Address == 5");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == 6, "MM_AppData.HkPacket.DataValue == 6");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 7, "MM_AppData.HkPacket.BytesProcessed == 7");
+    UtAssert_True(MM_AppData.HkPacket.Payload.CmdCounter == 1, "MM_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(MM_AppData.HkPacket.Payload.ErrCounter == 2, "MM_AppData.HkPacket.Payload.ErrCounter == 2");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == 3, "MM_AppData.HkPacket.Payload.LastAction == 3");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == 4, "MM_AppData.HkPacket.Payload.MemType == 4");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == 5, "MM_AppData.HkPacket.Payload.Address == 5");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == 6, "MM_AppData.HkPacket.Payload.DataValue == 6");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 7, "MM_AppData.HkPacket.Payload.BytesProcessed == 7");
 
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, MM_AppData.HkPacket.FileName, OS_MAX_PATH_LEN) == 0,
-                  "strncmp(MM_AppData.HkPacket.FileName, MM_AppData.HkPacket.FileName, OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, MM_AppData.HkPacket.Payload.FileName, OS_MAX_PATH_LEN) == 0,
+                  "strncmp(MM_AppData.HkPacket.Payload.FileName, MM_AppData.HkPacket.Payload.FileName, OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1198,8 +1198,8 @@ void MM_HousekeepingCmd_Test_NoLengthVerify(void)
     /* Execute the function being tested */
     MM_HousekeepingCmd(&UT_CmdBuf.Buf);
 
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1214,8 +1214,8 @@ void MM_ResetCmd_Test_NoLengthVerify(void)
     /* Execute the function being tested */
     MM_ResetCmd(&UT_CmdBuf.Buf);
 
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1238,7 +1238,7 @@ void MM_LookupSymbolCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    strncpy(UT_CmdBuf.LookupSymCmd.SymName, "name", sizeof(UT_CmdBuf.LookupSymCmd.SymName) - 1);
+    strncpy(UT_CmdBuf.LookupSymCmd.Payload.SymName, "name", sizeof(UT_CmdBuf.LookupSymCmd.Payload.SymName) - 1);
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -1249,10 +1249,10 @@ void MM_LookupSymbolCmd_Test_Nominal(void)
     MM_LookupSymbolCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_SYM_LOOKUP, "MM_AppData.HkPacket.LastAction == MM_SYM_LOOKUP");
-    UtAssert_True(MM_AppData.HkPacket.Address == 0, "MM_AppData.HkPacket.Address == 0");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_SYM_LOOKUP, "MM_AppData.HkPacket.Payload.LastAction == MM_SYM_LOOKUP");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == 0, "MM_AppData.HkPacket.Payload.Address == 0");
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_SYM_LOOKUP_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1281,7 +1281,7 @@ void MM_LookupSymbolCmd_Test_SymbolNameNull(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    UT_CmdBuf.LookupSymCmd.SymName[0] = '\0';
+    UT_CmdBuf.LookupSymCmd.Payload.SymName[0] = '\0';
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -1290,8 +1290,8 @@ void MM_LookupSymbolCmd_Test_SymbolNameNull(void)
     MM_LookupSymbolCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_SYMNAME_NUL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -1321,7 +1321,7 @@ void MM_LookupSymbolCmd_Test_SymbolLookupError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    strncpy(UT_CmdBuf.LookupSymCmd.SymName, "name", sizeof(UT_CmdBuf.LookupSymCmd.SymName) - 1);
+    strncpy(UT_CmdBuf.LookupSymCmd.Payload.SymName, "name", sizeof(UT_CmdBuf.LookupSymCmd.Payload.SymName) - 1);
 
     /* Set to generate error message MM_SYMNAME_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(OS_SymbolLookup), 1, -1);
@@ -1333,8 +1333,8 @@ void MM_LookupSymbolCmd_Test_SymbolLookupError(void)
     MM_LookupSymbolCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_SYMNAME_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -1356,8 +1356,8 @@ void MM_LookupSymbolCmd_Test_NoLengthVerify(void)
     /* Execute the function being tested */
     MM_LookupSymbolCmd(&UT_CmdBuf.Buf);
 
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1380,7 +1380,7 @@ void MM_SymTblToFileCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    strncpy(UT_CmdBuf.SymTblToFileCmd.FileName, "name", sizeof(UT_CmdBuf.SymTblToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.SymTblToFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.SymTblToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy condition "OS_Status == OS_SUCCESS" */
     UT_SetDeferredRetcode(UT_KEY(OS_SymbolTableDump), 1, CFE_SUCCESS);
@@ -1392,11 +1392,11 @@ void MM_SymTblToFileCmd_Test_Nominal(void)
     MM_SymTblToFileCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_SYMTBL_SAVE, "MM_AppData.HkPacket.LastAction == MM_SYMTBL_SAVE");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, UT_CmdBuf.SymTblToFileCmd.FileName, OS_MAX_PATH_LEN) == 0,
-                  "strncmp(MM_AppData.HkPacket.FileName, UT_CmdBuf.SymTblToFileCmd.FileName, OS_MAX_PATH_LEN) == 0");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_SYMTBL_SAVE, "MM_AppData.HkPacket.Payload.LastAction == MM_SYMTBL_SAVE");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, UT_CmdBuf.SymTblToFileCmd.Payload.FileName, OS_MAX_PATH_LEN) == 0,
+                  "strncmp(MM_AppData.HkPacket.Payload.FileName, UT_CmdBuf.SymTblToFileCmd.Payload.FileName, OS_MAX_PATH_LEN) == 0");
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_SYMTBL_TO_FILE_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1426,7 +1426,7 @@ void MM_SymTblToFileCmd_Test_SymbolFilenameNull(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    UT_CmdBuf.SymTblToFileCmd.FileName[0] = '\0';
+    UT_CmdBuf.SymTblToFileCmd.Payload.FileName[0] = '\0';
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -1435,8 +1435,8 @@ void MM_SymTblToFileCmd_Test_SymbolFilenameNull(void)
     MM_SymTblToFileCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_SYMFILENAME_NUL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -1466,7 +1466,7 @@ void MM_SymTblToFileCmd_Test_SymbolTableDumpError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    strncpy(UT_CmdBuf.SymTblToFileCmd.FileName, "name", sizeof(UT_CmdBuf.SymTblToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.SymTblToFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.SymTblToFileCmd.Payload.FileName) - 1);
 
     /* Set to generate error message MM_SYMTBL_TO_FILE_FAIL_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(OS_SymbolTableDump), 1, -1);
@@ -1478,8 +1478,8 @@ void MM_SymTblToFileCmd_Test_SymbolTableDumpError(void)
     MM_SymTblToFileCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_SYMTBL_TO_FILE_FAIL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -1501,8 +1501,8 @@ void MM_SymTblToFileCmd_Test_NoLengthVerify(void)
     /* Execute the function being tested */
     MM_SymTblToFileCmd(&UT_CmdBuf.Buf);
 
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1525,7 +1525,7 @@ void MM_EepromWriteEnaCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    UT_CmdBuf.EepromWriteEnaCmd.Bank = 0;
+    UT_CmdBuf.EepromWriteEnaCmd.Payload.Bank = 0;
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -1536,11 +1536,11 @@ void MM_EepromWriteEnaCmd_Test_Nominal(void)
     MM_EepromWriteEnaCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_EEPROMWRITE_ENA,
-                  "MM_AppData.HkPacket.LastAction == MM_EEPROMWRITE_ENA");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_EEPROM, "MM_AppData.HkPacket.MemType == MM_EEPROM");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_EEPROMWRITE_ENA,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_EEPROMWRITE_ENA");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_EEPROM, "MM_AppData.HkPacket.Payload.MemType == MM_EEPROM");
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_EEPROM_WRITE_ENA_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1571,7 +1571,7 @@ void MM_EepromWriteEnaCmd_Test_Error(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Stub will fail on bank 1 */
-    UT_CmdBuf.EepromWriteEnaCmd.Bank = 1;
+    UT_CmdBuf.EepromWriteEnaCmd.Payload.Bank = 1;
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -1583,8 +1583,8 @@ void MM_EepromWriteEnaCmd_Test_Error(void)
     MM_EepromWriteEnaCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_EEPROM_WRITE_ENA_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -1606,8 +1606,8 @@ void MM_EepromWriteEnaCmd_Test_NoLengthVerify(void)
     /* Execute the function being tested */
     MM_EepromWriteEnaCmd(&UT_CmdBuf.Buf);
 
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1630,7 +1630,7 @@ void MM_EepromWriteDisCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    UT_CmdBuf.EepromWriteDisCmd.Bank = 0;
+    UT_CmdBuf.EepromWriteDisCmd.Payload.Bank = 0;
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -1641,11 +1641,11 @@ void MM_EepromWriteDisCmd_Test_Nominal(void)
     MM_EepromWriteDisCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_EEPROMWRITE_DIS,
-                  "MM_AppData.HkPacket.LastAction == MM_EEPROMWRITE_DIS");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_EEPROM, "MM_AppData.HkPacket.MemType == MM_EEPROM");
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_EEPROMWRITE_DIS,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_EEPROMWRITE_DIS");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_EEPROM, "MM_AppData.HkPacket.Payload.MemType == MM_EEPROM");
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_EEPROM_WRITE_DIS_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1676,7 +1676,7 @@ void MM_EepromWriteDisCmd_Test_Error(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Stub will fail on bank 1 */
-    UT_CmdBuf.EepromWriteDisCmd.Bank = 1;
+    UT_CmdBuf.EepromWriteDisCmd.Payload.Bank = 1;
 
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
@@ -1688,8 +1688,8 @@ void MM_EepromWriteDisCmd_Test_Error(void)
     MM_EepromWriteDisCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_EEPROM_WRITE_DIS_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -1711,8 +1711,8 @@ void MM_EepromWriteDisCmd_Test_NoLengthVerify(void)
     /* Execute the function being tested */
     MM_EepromWriteDisCmd(&UT_CmdBuf.Buf);
 
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/mm_dump_tests.c
+++ b/unit-test/mm_dump_tests.c
@@ -91,8 +91,8 @@ void MM_PeekCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Peek Command: Addr = %%p Size = %%u bits Data = 0x%%08X");
 
-    UT_CmdBuf.PeekCmd.MemType  = MM_RAM;
-    UT_CmdBuf.PeekCmd.DataSize = 32;
+    UT_CmdBuf.PeekCmd.Payload.MemType  = MM_RAM;
+    UT_CmdBuf.PeekCmd.Payload.DataSize = 32;
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_PEEK_CC;
@@ -124,8 +124,8 @@ void MM_PeekCmd_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PeekCmd_Test_SymNameError(void)
@@ -144,10 +144,10 @@ void MM_PeekCmd_Test_SymNameError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.PeekCmd.MemType  = MM_RAM;
-    UT_CmdBuf.PeekCmd.DataSize = 32;
+    UT_CmdBuf.PeekCmd.Payload.MemType  = MM_RAM;
+    UT_CmdBuf.PeekCmd.Payload.DataSize = 32;
 
-    strncpy(UT_CmdBuf.PeekCmd.SrcSymAddress.SymName, "name", sizeof(UT_CmdBuf.PeekCmd.SrcSymAddress.SymName) - 1);
+    strncpy(UT_CmdBuf.PeekCmd.Payload.SrcSymAddress.SymName, "name", sizeof(UT_CmdBuf.PeekCmd.Payload.SrcSymAddress.SymName) - 1);
 
     /* Set to generate error message MM_SYMNAME_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(OS_SymbolLookup), 1, -1);
@@ -163,8 +163,8 @@ void MM_PeekCmd_Test_SymNameError(void)
     /* No command-handling function should be updating the cmd or err counter itself */
     UtAssert_True(Result == false, "Result == false");
 
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_SYMNAME_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -185,8 +185,8 @@ void MM_PeekCmd_Test_NoVerifyPeekPokeParams(void)
     CFE_MSG_FcnCode_t FcnCode;
     bool              Result;
 
-    UT_CmdBuf.PeekCmd.MemType  = MM_RAM;
-    UT_CmdBuf.PeekCmd.DataSize = 32;
+    UT_CmdBuf.PeekCmd.Payload.MemType  = MM_RAM;
+    UT_CmdBuf.PeekCmd.Payload.DataSize = 32;
 
     TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
     FcnCode   = MM_PEEK_CC;
@@ -207,8 +207,8 @@ void MM_PeekCmd_Test_NoVerifyPeekPokeParams(void)
     UtAssert_True(Result == false, "Result == false");
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -226,8 +226,8 @@ void MM_PeekMem_Test_Byte(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Peek Command: Addr = %%p Size = %%u bits Data = 0x%%08X");
 
-    CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
-    CmdPacket.MemType  = MM_RAM;
+    CmdPacket.Payload.DataSize = MM_BYTE_BIT_WIDTH;
+    CmdPacket.Payload.MemType  = MM_RAM;
 
     /* Execute the function being tested */
     Result = MM_PeekMem(&CmdPacket, SrcAddress);
@@ -243,14 +243,14 @@ void MM_PeekMem_Test_Byte(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_PEEK, "MM_AppData.HkPacket.LastAction == MM_PEEK");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_RAM, "MM_AppData.HkPacket.MemType == MM_RAM");
-    UtAssert_True(MM_AppData.HkPacket.Address == 1, "MM_AppData.HkPacket.Address == 1");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 1, "MM_AppData.HkPacket.BytesProcessed == 1");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == 1, "MM_AppData.HkPacket.DataValue == 1");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_PEEK, "MM_AppData.HkPacket.Payload.LastAction == MM_PEEK");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_RAM, "MM_AppData.HkPacket.Payload.MemType == MM_RAM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == 1, "MM_AppData.HkPacket.Payload.Address == 1");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 1, "MM_AppData.HkPacket.Payload.BytesProcessed == 1");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == 1, "MM_AppData.HkPacket.Payload.DataValue == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -269,7 +269,7 @@ void MM_PeekMem_Test_ByteError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP read memory error: RC=%%d, Address=%%p, MemType=MEM%%u");
 
-    CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
+    CmdPacket.Payload.DataSize = MM_BYTE_BIT_WIDTH;
 
     /* Set to generate error message MM_PSP_READ_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead8), 1, -1);
@@ -281,8 +281,8 @@ void MM_PeekMem_Test_ByteError(void)
     UtAssert_True(Result == false, "Result == false");
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
@@ -307,8 +307,8 @@ void MM_PeekMem_Test_Word(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Peek Command: Addr = %%p Size = %%u bits Data = 0x%%08X");
 
-    CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
-    CmdPacket.MemType  = MM_RAM;
+    CmdPacket.Payload.DataSize = MM_WORD_BIT_WIDTH;
+    CmdPacket.Payload.MemType  = MM_RAM;
 
     /* Execute the function being tested */
     Result = MM_PeekMem(&CmdPacket, SrcAddress);
@@ -324,14 +324,14 @@ void MM_PeekMem_Test_Word(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_PEEK, "MM_AppData.HkPacket.LastAction == MM_PEEK");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_RAM, "MM_AppData.HkPacket.MemType == MM_RAM");
-    UtAssert_True(MM_AppData.HkPacket.Address == 1, "MM_AppData.HkPacket.Address == 1");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 2, "MM_AppData.HkPacket.BytesProcessed == 2");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == 0, "MM_AppData.HkPacket.DataValue == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_PEEK, "MM_AppData.HkPacket.Payload.LastAction == MM_PEEK");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_RAM, "MM_AppData.HkPacket.Payload.MemType == MM_RAM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == 1, "MM_AppData.HkPacket.Payload.Address == 1");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 2, "MM_AppData.HkPacket.Payload.BytesProcessed == 2");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == 0, "MM_AppData.HkPacket.Payload.DataValue == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -350,7 +350,7 @@ void MM_PeekMem_Test_WordError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP read memory error: RC=%%d, Address=%%p, MemType=MEM%%u");
 
-    CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
+    CmdPacket.Payload.DataSize = MM_WORD_BIT_WIDTH;
 
     /* Set to generate error message MM_PSP_READ_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead16), 1, -1);
@@ -362,8 +362,8 @@ void MM_PeekMem_Test_WordError(void)
     UtAssert_True(Result == false, "Result == false");
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_PSP_READ_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -389,8 +389,8 @@ void MM_PeekMem_Test_DWord(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Peek Command: Addr = %%p Size = %%u bits Data = 0x%%08X");
 
-    CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
-    CmdPacket.MemType  = MM_RAM;
+    CmdPacket.Payload.DataSize = MM_DWORD_BIT_WIDTH;
+    CmdPacket.Payload.MemType  = MM_RAM;
 
     /* Execute the function being tested */
     Result = MM_PeekMem(&CmdPacket, SrcAddress);
@@ -406,14 +406,14 @@ void MM_PeekMem_Test_DWord(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_PEEK, "MM_AppData.HkPacket.LastAction == MM_PEEK");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_RAM, "MM_AppData.HkPacket.MemType == MM_RAM");
-    UtAssert_True(MM_AppData.HkPacket.Address == 1, "MM_AppData.HkPacket.Address == 1");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 4, "MM_AppData.HkPacket.BytesProcessed == 4");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == 0, "MM_AppData.HkPacket.DataValue == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_PEEK, "MM_AppData.HkPacket.Payload.LastAction == MM_PEEK");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_RAM, "MM_AppData.HkPacket.Payload.MemType == MM_RAM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == 1, "MM_AppData.HkPacket.Payload.Address == 1");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 4, "MM_AppData.HkPacket.Payload.BytesProcessed == 4");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == 0, "MM_AppData.HkPacket.Payload.DataValue == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -432,7 +432,7 @@ void MM_PeekMem_Test_DWordError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP read memory error: RC=%%d, Address=%%p, MemType=MEM%%u");
 
-    CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
+    CmdPacket.Payload.DataSize = MM_DWORD_BIT_WIDTH;
 
     /* Set to generate error message MM_PSP_READ_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead32), 1, -1);
@@ -456,8 +456,8 @@ void MM_PeekMem_Test_DWordError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PeekMem_Test_DefaultSwitch(void)
@@ -466,7 +466,7 @@ void MM_PeekMem_Test_DefaultSwitch(void)
     uint32       SrcAddress = 1;
     bool         Result;
 
-    CmdPacket.DataSize = 99;
+    CmdPacket.Payload.DataSize = 99;
 
     /* Execute the function being tested */
     Result = MM_PeekMem(&CmdPacket, SrcAddress);
@@ -480,8 +480,8 @@ void MM_PeekMem_Test_DefaultSwitch(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PeekMem_Test_NoLengthVerify(void)
@@ -501,8 +501,8 @@ void MM_PeekMem_Test_NoLengthVerify(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_RAM(void)
@@ -521,14 +521,14 @@ void MM_DumpMemToFileCmd_Test_RAM(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_RAM;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_RAM;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook1, 0);
@@ -560,16 +560,16 @@ void MM_DumpMemToFileCmd_Test_RAM(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset,
-                  "MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset");
-    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName),
-                          UT_CmdBuf.DumpMemToFileCmd.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName));
-    UtAssert_True(MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType,
-                  "MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == (cpuaddr)UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset,
+                  "MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset");
+    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.Payload.FileName, sizeof(MM_AppData.HkPacket.Payload.FileName),
+                          UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName));
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType,
+                  "MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -577,8 +577,8 @@ void MM_DumpMemToFileCmd_Test_RAM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_BadType(void)
@@ -592,14 +592,14 @@ void MM_DumpMemToFileCmd_Test_BadType(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = 99;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = 99;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook1, 0);
@@ -629,8 +629,8 @@ void MM_DumpMemToFileCmd_Test_BadType(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_EEPROM(void)
@@ -649,14 +649,14 @@ void MM_DumpMemToFileCmd_Test_EEPROM(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_EEPROM;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_EEPROM;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook1, 0);
@@ -688,14 +688,14 @@ void MM_DumpMemToFileCmd_Test_EEPROM(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName),
-                          UT_CmdBuf.DumpMemToFileCmd.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName));
-    UtAssert_True(MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType,
-                  "MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.Payload.FileName, sizeof(MM_AppData.HkPacket.Payload.FileName),
+                          UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName));
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType,
+                  "MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -703,8 +703,8 @@ void MM_DumpMemToFileCmd_Test_EEPROM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_MEM32(void)
@@ -723,14 +723,14 @@ void MM_DumpMemToFileCmd_Test_MEM32(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_MEM32;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 4;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_MEM32;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 4;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -761,14 +761,14 @@ void MM_DumpMemToFileCmd_Test_MEM32(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName),
-                          UT_CmdBuf.DumpMemToFileCmd.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName));
-    UtAssert_True(MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType,
-                  "MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.Payload.FileName, sizeof(MM_AppData.HkPacket.Payload.FileName),
+                          UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName));
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType,
+                  "MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -776,8 +776,8 @@ void MM_DumpMemToFileCmd_Test_MEM32(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_MEM16(void)
@@ -796,14 +796,14 @@ void MM_DumpMemToFileCmd_Test_MEM16(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_MEM16;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 2;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_MEM16;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 2;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -834,14 +834,14 @@ void MM_DumpMemToFileCmd_Test_MEM16(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName),
-                          UT_CmdBuf.DumpMemToFileCmd.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName));
-    UtAssert_True(MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType,
-                  "MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.Payload.FileName, sizeof(MM_AppData.HkPacket.Payload.FileName),
+                          UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName));
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType,
+                  "MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -849,8 +849,8 @@ void MM_DumpMemToFileCmd_Test_MEM16(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_MEM8(void)
@@ -869,14 +869,14 @@ void MM_DumpMemToFileCmd_Test_MEM8(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -906,14 +906,14 @@ void MM_DumpMemToFileCmd_Test_MEM8(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName),
-                          UT_CmdBuf.DumpMemToFileCmd.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName));
-    UtAssert_True(MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType,
-                  "MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.Payload.FileName, sizeof(MM_AppData.HkPacket.Payload.FileName),
+                          UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName));
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType,
+                  "MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -921,8 +921,8 @@ void MM_DumpMemToFileCmd_Test_MEM8(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_ComputeCRCError(void)
@@ -941,14 +941,14 @@ void MM_DumpMemToFileCmd_Test_ComputeCRCError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -988,8 +988,8 @@ void MM_DumpMemToFileCmd_Test_ComputeCRCError(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_CloseError(void)
@@ -1011,14 +1011,14 @@ void MM_DumpMemToFileCmd_Test_CloseError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -1061,14 +1061,14 @@ void MM_DumpMemToFileCmd_Test_CloseError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName),
-                          UT_CmdBuf.DumpMemToFileCmd.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName));
-    UtAssert_True(MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType,
-                  "MM_AppData.HkPacket.MemType == UT_CmdBuf.DumpMemToFileCmd.MemType");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.Payload.FileName, sizeof(MM_AppData.HkPacket.Payload.FileName),
+                          UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName));
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType,
+                  "MM_AppData.HkPacket.Payload.MemType == UT_CmdBuf.DumpMemToFileCmd.Payload.MemType");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1076,8 +1076,8 @@ void MM_DumpMemToFileCmd_Test_CloseError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_CreatError(void)
@@ -1096,14 +1096,14 @@ void MM_DumpMemToFileCmd_Test_CreatError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -1142,8 +1142,8 @@ void MM_DumpMemToFileCmd_Test_CreatError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_InvalidDumpResult(void)
@@ -1157,14 +1157,14 @@ void MM_DumpMemToFileCmd_Test_InvalidDumpResult(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -1193,8 +1193,8 @@ void MM_DumpMemToFileCmd_Test_InvalidDumpResult(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_lseekError(void)
@@ -1208,14 +1208,14 @@ void MM_DumpMemToFileCmd_Test_lseekError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -1244,8 +1244,8 @@ void MM_DumpMemToFileCmd_Test_lseekError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_SymNameError(void)
@@ -1264,14 +1264,14 @@ void MM_DumpMemToFileCmd_Test_SymNameError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -1305,8 +1305,8 @@ void MM_DumpMemToFileCmd_Test_SymNameError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_NoVerifyDumpParams(void)
@@ -1320,17 +1320,17 @@ void MM_DumpMemToFileCmd_Test_NoVerifyDumpParams(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType = MM_RAM;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType = MM_RAM;
     /* Set to fail MM_VerifyFileDumpParams */
 
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyLoadDumpParams), false);
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 0;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 0;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -1352,8 +1352,8 @@ void MM_DumpMemToFileCmd_Test_NoVerifyDumpParams(void)
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");
 
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1361,8 +1361,8 @@ void MM_DumpMemToFileCmd_Test_NoVerifyDumpParams(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_NoLengthVerify(void)
@@ -1383,8 +1383,8 @@ void MM_DumpMemToFileCmd_Test_NoLengthVerify(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFileCmd_Test_NoWriteHeaders(void)
@@ -1403,14 +1403,14 @@ void MM_DumpMemToFileCmd_Test_NoWriteHeaders(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName, "SymName",
-            sizeof(UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.SymName) - 1);
-    UT_CmdBuf.DumpMemToFileCmd.SrcSymAddress.Offset = 0;
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName, "SymName",
+            sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.SymName) - 1);
+    UT_CmdBuf.DumpMemToFileCmd.Payload.SrcSymAddress.Offset = 0;
 
-    UT_CmdBuf.DumpMemToFileCmd.MemType    = MM_RAM;
-    UT_CmdBuf.DumpMemToFileCmd.NumOfBytes = 1;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.MemType    = MM_RAM;
+    UT_CmdBuf.DumpMemToFileCmd.Payload.NumOfBytes = 1;
 
-    strncpy(UT_CmdBuf.DumpMemToFileCmd.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName, "filename", sizeof(UT_CmdBuf.DumpMemToFileCmd.Payload.FileName) - 1);
 
     /* Set to satisfy 2 instances of condition "Valid == true": after comment "Write the file headers" and comment "end
      * Valid == true if" */
@@ -1447,8 +1447,8 @@ void MM_DumpMemToFileCmd_Test_NoWriteHeaders(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFile_Test_Nominal(void)
@@ -1471,14 +1471,14 @@ void MM_DumpMemToFile_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == FileHeader.MemType,
-                  "MM_AppData.HkPacket.MemType == FileHeader.MemType");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)FileHeader.SymAddress.Offset,
-                  "MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 1, "MM_AppData.HkPacket.BytesProcessed == 1");
-    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName), FileName,
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == FileHeader.MemType,
+                  "MM_AppData.HkPacket.Payload.MemType == FileHeader.MemType");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == (cpuaddr)FileHeader.SymAddress.Offset,
+                  "MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 1, "MM_AppData.HkPacket.Payload.BytesProcessed == 1");
+    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.Payload.FileName, sizeof(MM_AppData.HkPacket.Payload.FileName), FileName,
                           sizeof(FileName));
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -1487,8 +1487,8 @@ void MM_DumpMemToFile_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFile_Test_CPUHogging(void)
@@ -1512,15 +1512,15 @@ void MM_DumpMemToFile_Test_CPUHogging(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == FileHeader.MemType,
-                  "MM_AppData.HkPacket.MemType == FileHeader.MemType");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)FileHeader.SymAddress.Offset,
-                  "MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 2 * MM_MAX_DUMP_DATA_SEG,
-                  "MM_AppData.HkPacket.BytesProcessed == 2 * MM_MAX_DUMP_DATA_SEG");
-    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName), FileName,
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == FileHeader.MemType,
+                  "MM_AppData.HkPacket.Payload.MemType == FileHeader.MemType");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == (cpuaddr)FileHeader.SymAddress.Offset,
+                  "MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 2 * MM_MAX_DUMP_DATA_SEG,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == 2 * MM_MAX_DUMP_DATA_SEG");
+    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.Payload.FileName, sizeof(MM_AppData.HkPacket.Payload.FileName), FileName,
                           sizeof(FileName));
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -1529,8 +1529,8 @@ void MM_DumpMemToFile_Test_CPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMemToFile_Test_WriteError(void)
@@ -1575,8 +1575,8 @@ void MM_DumpMemToFile_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_WriteFileHeaders_Test_Nominal(void)
@@ -1608,8 +1608,8 @@ void MM_WriteFileHeaders_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_WriteFileHeaders_Test_WriteHeaderError(void)
@@ -1654,8 +1654,8 @@ void MM_WriteFileHeaders_Test_WriteHeaderError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_WriteFileHeaders_Test_WriteError(void)
@@ -1700,8 +1700,8 @@ void MM_WriteFileHeaders_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpInEventCmd_Test_Nominal(void)
@@ -1722,11 +1722,11 @@ void MM_DumpInEventCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.DumpInEventCmd.MemType              = MM_RAM;
-    UT_CmdBuf.DumpInEventCmd.NumOfBytes           = 1;
-    UT_CmdBuf.DumpInEventCmd.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
+    UT_CmdBuf.DumpInEventCmd.Payload.MemType              = MM_RAM;
+    UT_CmdBuf.DumpInEventCmd.Payload.NumOfBytes           = 1;
+    UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
 
-    UT_CmdBuf.DumpInEventCmd.SrcSymAddress.SymName[0] = '\0';
+    UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.SymName[0] = '\0';
 
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook1, 0);
@@ -1749,12 +1749,12 @@ void MM_DumpInEventCmd_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_INEVENT,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_INEVENT");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_RAM, "MM_AppData.HkPacket.MemType == MM_RAM");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)UT_CmdBuf.DumpInEventCmd.SrcSymAddress.Offset,
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_INEVENT,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_INEVENT");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_RAM, "MM_AppData.HkPacket.Payload.MemType == MM_RAM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == (cpuaddr)UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.Offset,
                   "MM_AppData.HkPacketAddress == FileHeader.SymAddress.Offset");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 1, "MM_AppData.HkPacket.BytesProcessed == 1");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 1, "MM_AppData.HkPacket.Payload.BytesProcessed == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_DUMP_INEVENT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1770,8 +1770,8 @@ void MM_DumpInEventCmd_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpInEventCmd_Test_SymNameError(void)
@@ -1790,12 +1790,12 @@ void MM_DumpInEventCmd_Test_SymNameError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.DumpInEventCmd.MemType              = MM_RAM;
-    UT_CmdBuf.DumpInEventCmd.NumOfBytes           = 1;
-    UT_CmdBuf.DumpInEventCmd.SrcSymAddress.Offset = 0;
+    UT_CmdBuf.DumpInEventCmd.Payload.MemType              = MM_RAM;
+    UT_CmdBuf.DumpInEventCmd.Payload.NumOfBytes           = 1;
+    UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.Offset = 0;
 
-    strncpy(UT_CmdBuf.DumpInEventCmd.SrcSymAddress.SymName, "name",
-            sizeof(UT_CmdBuf.DumpInEventCmd.SrcSymAddress.SymName) - 1);
+    strncpy(UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.SymName, "name",
+            sizeof(UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.SymName) - 1);
 
     /* Set to generate error message MM_SYMNAME_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(OS_SymbolLookup), 1, -1);
@@ -1824,8 +1824,8 @@ void MM_DumpInEventCmd_Test_SymNameError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpInEventCmd_Test_NoLengthVerify(void)
@@ -1848,8 +1848,8 @@ void MM_DumpInEventCmd_Test_NoLengthVerify(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpInEventCmd_Test_NoVerifyDumpParams(void)
@@ -1863,12 +1863,12 @@ void MM_DumpInEventCmd_Test_NoVerifyDumpParams(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.DumpInEventCmd.MemType              = MM_RAM;
-    UT_CmdBuf.DumpInEventCmd.NumOfBytes           = 0;
-    UT_CmdBuf.DumpInEventCmd.SrcSymAddress.Offset = 0;
+    UT_CmdBuf.DumpInEventCmd.Payload.MemType              = MM_RAM;
+    UT_CmdBuf.DumpInEventCmd.Payload.NumOfBytes           = 0;
+    UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.Offset = 0;
 
-    strncpy(UT_CmdBuf.DumpInEventCmd.SrcSymAddress.SymName, "name",
-            sizeof(UT_CmdBuf.DumpInEventCmd.SrcSymAddress.SymName) - 1);
+    strncpy(UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.SymName, "name",
+            sizeof(UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.SymName) - 1);
 
     UT_SetDeferredRetcode(UT_KEY(MM_ResolveSymAddr), 1, true);
 
@@ -1887,8 +1887,8 @@ void MM_DumpInEventCmd_Test_NoVerifyDumpParams(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpInEventCmd_Test_FillDumpInvalid(void)
@@ -1902,11 +1902,11 @@ void MM_DumpInEventCmd_Test_FillDumpInvalid(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.DumpInEventCmd.MemType              = MM_MEM8;
-    UT_CmdBuf.DumpInEventCmd.NumOfBytes           = 1;
-    UT_CmdBuf.DumpInEventCmd.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
+    UT_CmdBuf.DumpInEventCmd.Payload.MemType              = MM_MEM8;
+    UT_CmdBuf.DumpInEventCmd.Payload.NumOfBytes           = 1;
+    UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.Offset = (cpuaddr)&Buffer[0];
 
-    UT_CmdBuf.DumpInEventCmd.SrcSymAddress.SymName[0] = '\0';
+    UT_CmdBuf.DumpInEventCmd.Payload.SrcSymAddress.SymName[0] = '\0';
 
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook1, 0);
@@ -1936,8 +1936,8 @@ void MM_DumpInEventCmd_Test_FillDumpInvalid(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillDumpInEventBuffer_Test_RAM(void)
@@ -1947,9 +1947,9 @@ void MM_FillDumpInEventBuffer_Test_RAM(void)
     cpuaddr SrcAddress = (cpuaddr)&MM_AppData.LoadBuffer[0];
     bool    Result;
 
-    CmdPacket.MemType              = MM_RAM;
-    CmdPacket.NumOfBytes           = 1;
-    CmdPacket.SrcSymAddress.Offset = 0;
+    CmdPacket.Payload.MemType              = MM_RAM;
+    CmdPacket.Payload.NumOfBytes           = 1;
+    CmdPacket.Payload.SrcSymAddress.Offset = 0;
 
     /* Execute the function being tested */
     Result = MM_FillDumpInEventBuffer(SrcAddress, &CmdPacket, (uint8 *)(&MM_AppData.DumpBuffer[0]));
@@ -1963,8 +1963,8 @@ void MM_FillDumpInEventBuffer_Test_RAM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillDumpInEventBuffer_Test_BadType(void)
@@ -1974,9 +1974,9 @@ void MM_FillDumpInEventBuffer_Test_BadType(void)
     cpuaddr SrcAddress = (cpuaddr)&MM_AppData.LoadBuffer[0];
     bool    Result;
 
-    CmdPacket.MemType              = 99;
-    CmdPacket.NumOfBytes           = 1;
-    CmdPacket.SrcSymAddress.Offset = 0;
+    CmdPacket.Payload.MemType              = 99;
+    CmdPacket.Payload.NumOfBytes           = 1;
+    CmdPacket.Payload.SrcSymAddress.Offset = 0;
 
     /* Execute the function being tested */
     Result = MM_FillDumpInEventBuffer(SrcAddress, &CmdPacket, (uint8 *)(&MM_AppData.DumpBuffer[0]));
@@ -1990,8 +1990,8 @@ void MM_FillDumpInEventBuffer_Test_BadType(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillDumpInEventBuffer_Test_EEPROM(void)
@@ -2001,9 +2001,9 @@ void MM_FillDumpInEventBuffer_Test_EEPROM(void)
     cpuaddr SrcAddress = (cpuaddr)&MM_AppData.LoadBuffer[0];
     bool    Result;
 
-    CmdPacket.MemType              = MM_EEPROM;
-    CmdPacket.NumOfBytes           = 1;
-    CmdPacket.SrcSymAddress.Offset = 0;
+    CmdPacket.Payload.MemType              = MM_EEPROM;
+    CmdPacket.Payload.NumOfBytes           = 1;
+    CmdPacket.Payload.SrcSymAddress.Offset = 0;
 
     /* Execute the function being tested */
     Result = MM_FillDumpInEventBuffer(SrcAddress, &CmdPacket, (uint8 *)(&MM_AppData.DumpBuffer[0]));
@@ -2017,8 +2017,8 @@ void MM_FillDumpInEventBuffer_Test_EEPROM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillDumpInEventBuffer_Test_MEM32(void)
@@ -2028,9 +2028,9 @@ void MM_FillDumpInEventBuffer_Test_MEM32(void)
     cpuaddr SrcAddress = 1;
     bool    Result;
 
-    CmdPacket.MemType              = MM_MEM32;
-    CmdPacket.NumOfBytes           = 4;
-    CmdPacket.SrcSymAddress.Offset = 0;
+    CmdPacket.Payload.MemType              = MM_MEM32;
+    CmdPacket.Payload.NumOfBytes           = 4;
+    CmdPacket.Payload.SrcSymAddress.Offset = 0;
 
     /* Execute the function being tested */
     Result = MM_FillDumpInEventBuffer(SrcAddress, &CmdPacket, (uint8 *)(&MM_AppData.DumpBuffer[0]));
@@ -2044,8 +2044,8 @@ void MM_FillDumpInEventBuffer_Test_MEM32(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillDumpInEventBuffer_Test_MEM16(void)
@@ -2055,9 +2055,9 @@ void MM_FillDumpInEventBuffer_Test_MEM16(void)
     cpuaddr SrcAddress = 1;
     bool    Result;
 
-    CmdPacket.MemType              = MM_MEM16;
-    CmdPacket.NumOfBytes           = 2;
-    CmdPacket.SrcSymAddress.Offset = 0;
+    CmdPacket.Payload.MemType              = MM_MEM16;
+    CmdPacket.Payload.NumOfBytes           = 2;
+    CmdPacket.Payload.SrcSymAddress.Offset = 0;
 
     /* Execute the function being tested */
     Result = MM_FillDumpInEventBuffer(SrcAddress, &CmdPacket, (uint8 *)(&MM_AppData.DumpBuffer[0]));
@@ -2071,8 +2071,8 @@ void MM_FillDumpInEventBuffer_Test_MEM16(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillDumpInEventBuffer_Test_MEM8(void)
@@ -2081,9 +2081,9 @@ void MM_FillDumpInEventBuffer_Test_MEM8(void)
     cpuaddr             SrcAddress = 0;
     bool                Result;
 
-    CmdPacket.MemType              = MM_MEM8;
-    CmdPacket.NumOfBytes           = 1;
-    CmdPacket.SrcSymAddress.Offset = 0;
+    CmdPacket.Payload.MemType              = MM_MEM8;
+    CmdPacket.Payload.NumOfBytes           = 1;
+    CmdPacket.Payload.SrcSymAddress.Offset = 0;
 
     /* Execute the function being tested */
     Result = MM_FillDumpInEventBuffer(SrcAddress, &CmdPacket, (uint8 *)(&MM_AppData.DumpBuffer[0]));
@@ -2097,8 +2097,8 @@ void MM_FillDumpInEventBuffer_Test_MEM8(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillDumpInEventBuffer_Test_MEM32ReadError(void)
@@ -2112,9 +2112,9 @@ void MM_FillDumpInEventBuffer_Test_MEM32ReadError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP read memory error: RC=%%d, Src=%%p, Tgt=%%p, Type=MEM32");
 
-    CmdPacket.MemType              = MM_MEM32;
-    CmdPacket.NumOfBytes           = 4;
-    CmdPacket.SrcSymAddress.Offset = 0;
+    CmdPacket.Payload.MemType              = MM_MEM32;
+    CmdPacket.Payload.NumOfBytes           = 4;
+    CmdPacket.Payload.SrcSymAddress.Offset = 0;
 
     /* Set to generate error message MM_PSP_READ_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead32), 1, -1);
@@ -2138,8 +2138,8 @@ void MM_FillDumpInEventBuffer_Test_MEM32ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillDumpInEventBuffer_Test_MEM16ReadError(void)
@@ -2153,9 +2153,9 @@ void MM_FillDumpInEventBuffer_Test_MEM16ReadError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP read memory error: RC=%%d, Src=%%p, Tgt=%%p, Type=MEM16");
 
-    CmdPacket.MemType              = MM_MEM16;
-    CmdPacket.NumOfBytes           = 4;
-    CmdPacket.SrcSymAddress.Offset = 0;
+    CmdPacket.Payload.MemType              = MM_MEM16;
+    CmdPacket.Payload.NumOfBytes           = 4;
+    CmdPacket.Payload.SrcSymAddress.Offset = 0;
 
     /* Set to generate error message MM_PSP_READ_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead16), 1, -1);
@@ -2179,8 +2179,8 @@ void MM_FillDumpInEventBuffer_Test_MEM16ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillDumpInEventBuffer_Test_MEM8ReadError(void)
@@ -2194,9 +2194,9 @@ void MM_FillDumpInEventBuffer_Test_MEM8ReadError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP read memory error: RC=%%d, Src=%%p, Tgt=%%p, Type=MEM8");
 
-    CmdPacket.MemType              = MM_MEM8;
-    CmdPacket.NumOfBytes           = 4;
-    CmdPacket.SrcSymAddress.Offset = 0;
+    CmdPacket.Payload.MemType              = MM_MEM8;
+    CmdPacket.Payload.NumOfBytes           = 4;
+    CmdPacket.Payload.SrcSymAddress.Offset = 0;
 
     /* Set to generate error message MM_PSP_READ_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead8), 1, -1);
@@ -2220,8 +2220,8 @@ void MM_FillDumpInEventBuffer_Test_MEM8ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 /*

--- a/unit-test/mm_load_tests.c
+++ b/unit-test/mm_load_tests.c
@@ -66,7 +66,7 @@ uint8 Buffer[MM_MAX_FILL_DATA_SEG * 2];
 int32 UT_MM_LOAD_TEST_MM_FillMemHook1(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                       const UT_StubContext_t *Context)
 {
-    MM_AppData.HkPacket.LastAction = MM_FILL;
+    MM_AppData.HkPacket.Payload.LastAction = MM_FILL;
 
     return true;
 }
@@ -215,8 +215,8 @@ void MM_PokeCmd_Test_EEPROM(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.PokeCmd.MemType  = MM_EEPROM;
-    UT_CmdBuf.PokeCmd.DataSize = 32;
+    UT_CmdBuf.PokeCmd.Payload.MemType  = MM_EEPROM;
+    UT_CmdBuf.PokeCmd.Payload.DataSize = 32;
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -242,8 +242,8 @@ void MM_PokeCmd_Test_EEPROM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeCmd_Test_NonEEPROM(void)
@@ -262,8 +262,8 @@ void MM_PokeCmd_Test_NonEEPROM(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.PokeCmd.MemType  = MM_RAM;
-    UT_CmdBuf.PokeCmd.DataSize = 32;
+    UT_CmdBuf.PokeCmd.Payload.MemType  = MM_RAM;
+    UT_CmdBuf.PokeCmd.Payload.DataSize = 32;
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -289,8 +289,8 @@ void MM_PokeCmd_Test_NonEEPROM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeCmd_Test_SymNameError(void)
@@ -309,8 +309,8 @@ void MM_PokeCmd_Test_SymNameError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.PokeCmd.MemType  = MM_RAM;
-    UT_CmdBuf.PokeCmd.DataSize = 32;
+    UT_CmdBuf.PokeCmd.Payload.MemType  = MM_RAM;
+    UT_CmdBuf.PokeCmd.Payload.DataSize = 32;
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -334,8 +334,8 @@ void MM_PokeCmd_Test_SymNameError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeCmd_Test_NoVerifyCmdLength(void)
@@ -355,8 +355,8 @@ void MM_PokeCmd_Test_NoVerifyCmdLength(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeCmd_Test_NoVerifyPeekPokeParams(void)
@@ -370,8 +370,8 @@ void MM_PokeCmd_Test_NoVerifyPeekPokeParams(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.PokeCmd.MemType  = MM_RAM;
-    UT_CmdBuf.PokeCmd.DataSize = 32;
+    UT_CmdBuf.PokeCmd.Payload.MemType  = MM_RAM;
+    UT_CmdBuf.PokeCmd.Payload.DataSize = 32;
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -390,16 +390,16 @@ void MM_PokeCmd_Test_NoVerifyPeekPokeParams(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeMem_Test_NoDataSize(void)
 {
     MM_PokeCmd_t CmdPacket;
     uint32       DestAddress;
-    CmdPacket.MemType  = MM_RAM;
-    CmdPacket.DataSize = 0;
+    CmdPacket.Payload.MemType  = MM_RAM;
+    CmdPacket.Payload.DataSize = 0;
     bool Result;
 
     DestAddress = 1;
@@ -416,8 +416,8 @@ void MM_PokeMem_Test_NoDataSize(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeMem_Test_8bit(void)
@@ -431,9 +431,9 @@ void MM_PokeMem_Test_8bit(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Poke Command: Addr = %%p, Size = %%u bits, Data = 0x%%08X");
 
-    CmdPacket.MemType  = MM_RAM;
-    CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
-    CmdPacket.Data     = (uint8)(5);
+    CmdPacket.Payload.MemType  = MM_RAM;
+    CmdPacket.Payload.DataSize = MM_BYTE_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint8)(5);
 
     DestAddress = 1;
 
@@ -443,11 +443,11 @@ void MM_PokeMem_Test_8bit(void)
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_POKE, "MM_AppData.HkPacket.LastAction == MM_POKE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_RAM, "MM_AppData.HkPacket.MemType == MM_RAM");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == 5, "MM_AppData.HkPacket.DataValue  == 5");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 1, "MM_AppData.HkPacket.BytesProcessed == 1");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_POKE, "MM_AppData.HkPacket.Payload.LastAction == MM_POKE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_RAM, "MM_AppData.HkPacket.Payload.MemType == MM_RAM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == 5, "MM_AppData.HkPacket.Payload.DataValue  == 5");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 1, "MM_AppData.HkPacket.Payload.BytesProcessed == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_POKE_BYTE_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -462,8 +462,8 @@ void MM_PokeMem_Test_8bit(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeMem_Test_8bitError(void)
@@ -477,9 +477,9 @@ void MM_PokeMem_Test_8bitError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%u");
 
-    CmdPacket.MemType  = MM_RAM;
-    CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
-    CmdPacket.Data     = (uint8)(5);
+    CmdPacket.Payload.MemType  = MM_RAM;
+    CmdPacket.Payload.DataSize = MM_BYTE_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint8)(5);
 
     /* CFE_PSP_MemWrite8 stub returns success with non-zero address */
     DestAddress = 0;
@@ -506,8 +506,8 @@ void MM_PokeMem_Test_8bitError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeMem_Test_16bit(void)
@@ -521,9 +521,9 @@ void MM_PokeMem_Test_16bit(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Poke Command: Addr = %%p, Size = %%u bits, Data = 0x%%08X");
 
-    CmdPacket.MemType  = MM_RAM;
-    CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
-    CmdPacket.Data     = (uint16)(5);
+    CmdPacket.Payload.MemType  = MM_RAM;
+    CmdPacket.Payload.DataSize = MM_WORD_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint16)(5);
 
     DestAddress = 1;
 
@@ -533,11 +533,11 @@ void MM_PokeMem_Test_16bit(void)
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_POKE, "MM_AppData.HkPacket.LastAction == MM_POKE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_RAM, "MM_AppData.HkPacket.MemType == MM_RAM");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == 5, "MM_AppData.HkPacket.DataValue  == 5");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 2, "MM_AppData.HkPacket.BytesProcessed == 2");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_POKE, "MM_AppData.HkPacket.Payload.LastAction == MM_POKE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_RAM, "MM_AppData.HkPacket.Payload.MemType == MM_RAM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == 5, "MM_AppData.HkPacket.Payload.DataValue  == 5");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 2, "MM_AppData.HkPacket.Payload.BytesProcessed == 2");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_POKE_WORD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -552,8 +552,8 @@ void MM_PokeMem_Test_16bit(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeMem_Test_16bitError(void)
@@ -567,9 +567,9 @@ void MM_PokeMem_Test_16bitError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%u");
 
-    CmdPacket.MemType  = MM_RAM;
-    CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
-    CmdPacket.Data     = (uint16)(5);
+    CmdPacket.Payload.MemType  = MM_RAM;
+    CmdPacket.Payload.DataSize = MM_WORD_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint16)(5);
 
     /* CFE_PSP_MemWrite16 stub returns success with non-zero address */
     DestAddress = 0;
@@ -596,8 +596,8 @@ void MM_PokeMem_Test_16bitError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeMem_Test_32bit(void)
@@ -611,9 +611,9 @@ void MM_PokeMem_Test_32bit(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Poke Command: Addr = %%p, Size = %%u bits, Data = 0x%%08X");
 
-    CmdPacket.MemType  = MM_RAM;
-    CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
-    CmdPacket.Data     = (uint32)(5);
+    CmdPacket.Payload.MemType  = MM_RAM;
+    CmdPacket.Payload.DataSize = MM_DWORD_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint32)(5);
 
     DestAddress = 1;
 
@@ -623,11 +623,11 @@ void MM_PokeMem_Test_32bit(void)
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_POKE, "MM_AppData.HkPacket.LastAction == MM_POKE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_RAM, "MM_AppData.HkPacket.MemType == MM_RAM");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == 5, "MM_AppData.HkPacket.DataValue  == 5");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 4, "MM_AppData.HkPacket.BytesProcessed == 4");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_POKE, "MM_AppData.HkPacket.Payload.LastAction == MM_POKE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_RAM, "MM_AppData.HkPacket.Payload.MemType == MM_RAM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == 5, "MM_AppData.HkPacket.Payload.DataValue  == 5");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 4, "MM_AppData.HkPacket.Payload.BytesProcessed == 4");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_POKE_DWORD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -642,8 +642,8 @@ void MM_PokeMem_Test_32bit(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeMem_Test_32bitError(void)
@@ -657,9 +657,9 @@ void MM_PokeMem_Test_32bitError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM%%u");
 
-    CmdPacket.MemType  = MM_RAM;
-    CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
-    CmdPacket.Data     = (uint32)(5);
+    CmdPacket.Payload.MemType  = MM_RAM;
+    CmdPacket.Payload.DataSize = MM_DWORD_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint32)(5);
 
     /* CFE_PSP_MemWrite32 stub returns success with non-zero address */
     DestAddress = 0;
@@ -686,8 +686,8 @@ void MM_PokeMem_Test_32bitError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeEeprom_Test_NoDataSize(void)
@@ -696,8 +696,8 @@ void MM_PokeEeprom_Test_NoDataSize(void)
     uint32       DestAddress;
     bool         Result;
 
-    CmdPacket.MemType  = MM_EEPROM;
-    CmdPacket.DataSize = 0;
+    CmdPacket.Payload.MemType  = MM_EEPROM;
+    CmdPacket.Payload.DataSize = 0;
 
     DestAddress = 1;
 
@@ -713,8 +713,8 @@ void MM_PokeEeprom_Test_NoDataSize(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeEeprom_Test_8bit(void)
@@ -728,9 +728,9 @@ void MM_PokeEeprom_Test_8bit(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Poke Command: Addr = %%p, Size = 8 bits, Data = 0x%%02X");
 
-    CmdPacket.MemType  = MM_EEPROM;
-    CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
-    CmdPacket.Data     = (uint8)(5);
+    CmdPacket.Payload.MemType  = MM_EEPROM;
+    CmdPacket.Payload.DataSize = MM_BYTE_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint8)(5);
 
     DestAddress = 1;
 
@@ -740,11 +740,11 @@ void MM_PokeEeprom_Test_8bit(void)
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_POKE, "MM_AppData.HkPacket.LastAction == MM_POKE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_EEPROM, "MM_AppData.HkPacket.MemType == MM_EEPROM");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == 5, "MM_AppData.HkPacket.DataValue  == 5");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 1, "MM_AppData.HkPacket.BytesProcessed == 1");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_POKE, "MM_AppData.HkPacket.Payload.LastAction == MM_POKE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_EEPROM, "MM_AppData.HkPacket.Payload.MemType == MM_EEPROM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == 5, "MM_AppData.HkPacket.Payload.DataValue  == 5");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 1, "MM_AppData.HkPacket.Payload.BytesProcessed == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_POKE_BYTE_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -759,8 +759,8 @@ void MM_PokeEeprom_Test_8bit(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeEeprom_Test_8bitError(void)
@@ -774,9 +774,9 @@ void MM_PokeEeprom_Test_8bitError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CFE_PSP_EepromWrite8 error received: RC = 0x%%08X, Addr = %%p");
 
-    CmdPacket.MemType  = MM_EEPROM;
-    CmdPacket.DataSize = MM_BYTE_BIT_WIDTH;
-    CmdPacket.Data     = (uint8)(5);
+    CmdPacket.Payload.MemType  = MM_EEPROM;
+    CmdPacket.Payload.DataSize = MM_BYTE_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint8)(5);
 
     /* CFE_PSP_MemWrite8 stub returns success with non-zero address */
     DestAddress = 0;
@@ -803,8 +803,8 @@ void MM_PokeEeprom_Test_8bitError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeEeprom_Test_16bit(void)
@@ -818,9 +818,9 @@ void MM_PokeEeprom_Test_16bit(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Poke Command: Addr = %%p, Size = 16 bits, Data = 0x%%04X");
 
-    CmdPacket.MemType  = MM_EEPROM;
-    CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
-    CmdPacket.Data     = (uint16)(5);
+    CmdPacket.Payload.MemType  = MM_EEPROM;
+    CmdPacket.Payload.DataSize = MM_WORD_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint16)(5);
 
     DestAddress = 1;
 
@@ -830,11 +830,11 @@ void MM_PokeEeprom_Test_16bit(void)
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_POKE, "MM_AppData.HkPacket.LastAction == MM_POKE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_EEPROM, "MM_AppData.HkPacket.MemType == MM_EEPROM");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == 5, "MM_AppData.HkPacket.DataValue  == 5");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 2, "MM_AppData.HkPacket.BytesProcessed == 2");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_POKE, "MM_AppData.HkPacket.Payload.LastAction == MM_POKE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_EEPROM, "MM_AppData.HkPacket.Payload.MemType == MM_EEPROM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == 5, "MM_AppData.HkPacket.Payload.DataValue  == 5");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 2, "MM_AppData.HkPacket.Payload.BytesProcessed == 2");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_POKE_WORD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -849,8 +849,8 @@ void MM_PokeEeprom_Test_16bit(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeEeprom_Test_16bitError(void)
@@ -864,9 +864,9 @@ void MM_PokeEeprom_Test_16bitError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CFE_PSP_EepromWrite16 error received: RC = 0x%%08X, Addr = %%p");
 
-    CmdPacket.MemType  = MM_EEPROM;
-    CmdPacket.DataSize = MM_WORD_BIT_WIDTH;
-    CmdPacket.Data     = (uint16)(5);
+    CmdPacket.Payload.MemType  = MM_EEPROM;
+    CmdPacket.Payload.DataSize = MM_WORD_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint16)(5);
 
     /* CFE_PSP_MemWrite16 stub returns success with non-zero address */
     DestAddress = 0;
@@ -893,8 +893,8 @@ void MM_PokeEeprom_Test_16bitError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeEeprom_Test_32bit(void)
@@ -908,9 +908,9 @@ void MM_PokeEeprom_Test_32bit(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Poke Command: Addr = %%p, Size = 32 bits, Data = 0x%%08X");
 
-    CmdPacket.MemType  = MM_EEPROM;
-    CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
-    CmdPacket.Data     = (uint32)(5);
+    CmdPacket.Payload.MemType  = MM_EEPROM;
+    CmdPacket.Payload.DataSize = MM_DWORD_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint32)(5);
 
     DestAddress = 1;
 
@@ -920,11 +920,11 @@ void MM_PokeEeprom_Test_32bit(void)
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_POKE, "MM_AppData.HkPacket.LastAction == MM_POKE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_EEPROM, "MM_AppData.HkPacket.MemType == MM_EEPROM");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == 5, "MM_AppData.HkPacket.DataValue  == 5");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 4, "MM_AppData.HkPacket.BytesProcessed == 4");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_POKE, "MM_AppData.HkPacket.Payload.LastAction == MM_POKE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_EEPROM, "MM_AppData.HkPacket.Payload.MemType == MM_EEPROM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == 5, "MM_AppData.HkPacket.Payload.DataValue  == 5");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 4, "MM_AppData.HkPacket.Payload.BytesProcessed == 4");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MM_POKE_DWORD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -939,8 +939,8 @@ void MM_PokeEeprom_Test_32bit(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_PokeEeprom_Test_32bitError(void)
@@ -954,9 +954,9 @@ void MM_PokeEeprom_Test_32bitError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CFE_PSP_EepromWrite32 error received: RC = 0x%%08X, Addr = %%p");
 
-    CmdPacket.MemType  = MM_EEPROM;
-    CmdPacket.DataSize = MM_DWORD_BIT_WIDTH;
-    CmdPacket.Data     = (uint32)(5);
+    CmdPacket.Payload.MemType  = MM_EEPROM;
+    CmdPacket.Payload.DataSize = MM_DWORD_BIT_WIDTH;
+    CmdPacket.Payload.Data     = (uint32)(5);
 
     /* CFE_PSP_MemWrite32 stub returns success with non-zero address */
     DestAddress = 0;
@@ -983,8 +983,8 @@ void MM_PokeEeprom_Test_32bitError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemWIDCmd_Test_Nominal(void)
@@ -1003,13 +1003,13 @@ void MM_LoadMemWIDCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.LoadMemWIDCmd.DataArray[0]          = 1;
-    UT_CmdBuf.LoadMemWIDCmd.DataArray[1]          = 2;
-    UT_CmdBuf.LoadMemWIDCmd.NumOfBytes            = 2;
-    UT_CmdBuf.LoadMemWIDCmd.Crc                   = 0;
-    UT_CmdBuf.LoadMemWIDCmd.DestSymAddress.Offset = 0;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DataArray[0]          = 1;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DataArray[1]          = 2;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.NumOfBytes            = 2;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.Crc                   = 0;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DestSymAddress.Offset = 0;
 
-    UT_CmdBuf.LoadMemWIDCmd.DestSymAddress.SymName[0] = '\0';
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DestSymAddress.SymName[0] = '\0';
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -1038,8 +1038,8 @@ void MM_LoadMemWIDCmd_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemWIDCmd_Test_NoVerifyCmdLength(void)
@@ -1059,8 +1059,8 @@ void MM_LoadMemWIDCmd_Test_NoVerifyCmdLength(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemWIDCmd_Test_CRCError(void)
@@ -1079,13 +1079,13 @@ void MM_LoadMemWIDCmd_Test_CRCError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.LoadMemWIDCmd.DataArray[0]          = 1;
-    UT_CmdBuf.LoadMemWIDCmd.DataArray[1]          = 2;
-    UT_CmdBuf.LoadMemWIDCmd.NumOfBytes            = 2;
-    UT_CmdBuf.LoadMemWIDCmd.Crc                   = 1;
-    UT_CmdBuf.LoadMemWIDCmd.DestSymAddress.Offset = 1;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DataArray[0]          = 1;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DataArray[1]          = 2;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.NumOfBytes            = 2;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.Crc                   = 1;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DestSymAddress.Offset = 1;
 
-    UT_CmdBuf.LoadMemWIDCmd.DestSymAddress.SymName[0] = '\0';
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DestSymAddress.SymName[0] = '\0';
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -1111,8 +1111,8 @@ void MM_LoadMemWIDCmd_Test_CRCError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemWIDCmd_Test_SymNameErr(void)
@@ -1131,13 +1131,13 @@ void MM_LoadMemWIDCmd_Test_SymNameErr(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.LoadMemWIDCmd.DataArray[0]          = 1;
-    UT_CmdBuf.LoadMemWIDCmd.DataArray[1]          = 2;
-    UT_CmdBuf.LoadMemWIDCmd.NumOfBytes            = 2;
-    UT_CmdBuf.LoadMemWIDCmd.Crc                   = 0;
-    UT_CmdBuf.LoadMemWIDCmd.DestSymAddress.Offset = 1;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DataArray[0]          = 1;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DataArray[1]          = 2;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.NumOfBytes            = 2;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.Crc                   = 0;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DestSymAddress.Offset = 1;
 
-    UT_CmdBuf.LoadMemWIDCmd.DestSymAddress.SymName[0] = '\0';
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DestSymAddress.SymName[0] = '\0';
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -1163,8 +1163,8 @@ void MM_LoadMemWIDCmd_Test_SymNameErr(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemWIDCmd_Test_NoVerifyLoadWIDParams(void)
@@ -1178,13 +1178,13 @@ void MM_LoadMemWIDCmd_Test_NoVerifyLoadWIDParams(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.LoadMemWIDCmd.DataArray[0]          = 1;
-    UT_CmdBuf.LoadMemWIDCmd.DataArray[1]          = 2;
-    UT_CmdBuf.LoadMemWIDCmd.NumOfBytes            = 0;
-    UT_CmdBuf.LoadMemWIDCmd.Crc                   = 0;
-    UT_CmdBuf.LoadMemWIDCmd.DestSymAddress.Offset = 1;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DataArray[0]          = 1;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DataArray[1]          = 2;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.NumOfBytes            = 0;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.Crc                   = 0;
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DestSymAddress.Offset = 1;
 
-    UT_CmdBuf.LoadMemWIDCmd.DestSymAddress.SymName[0] = '\0';
+    UT_CmdBuf.LoadMemWIDCmd.Payload.DestSymAddress.SymName[0] = '\0';
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -1203,8 +1203,8 @@ void MM_LoadMemWIDCmd_Test_NoVerifyLoadWIDParams(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_RAM(void)
@@ -1218,7 +1218,7 @@ void MM_LoadMemFromFileCmd_Test_RAM(void)
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_RAM;
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1261,15 +1261,15 @@ void MM_LoadMemFromFileCmd_Test_RAM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_BadType(void)
 {
     bool Result;
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1304,8 +1304,8 @@ void MM_LoadMemFromFileCmd_Test_BadType(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_EEPROM(void)
@@ -1319,7 +1319,7 @@ void MM_LoadMemFromFileCmd_Test_EEPROM(void)
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_EEPROM;
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1359,8 +1359,8 @@ void MM_LoadMemFromFileCmd_Test_EEPROM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_MEM32(void)
@@ -1374,7 +1374,7 @@ void MM_LoadMemFromFileCmd_Test_MEM32(void)
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_MEM32;
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1416,8 +1416,8 @@ void MM_LoadMemFromFileCmd_Test_MEM32(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_MEM32Invalid(void)
@@ -1426,7 +1426,7 @@ void MM_LoadMemFromFileCmd_Test_MEM32Invalid(void)
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_MEM32;
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1461,8 +1461,8 @@ void MM_LoadMemFromFileCmd_Test_MEM32Invalid(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_MEM16(void)
@@ -1476,7 +1476,7 @@ void MM_LoadMemFromFileCmd_Test_MEM16(void)
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_MEM16;
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1519,8 +1519,8 @@ void MM_LoadMemFromFileCmd_Test_MEM16(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_MEM8(void)
@@ -1534,7 +1534,7 @@ void MM_LoadMemFromFileCmd_Test_MEM8(void)
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_MEM8;
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1575,8 +1575,8 @@ void MM_LoadMemFromFileCmd_Test_MEM8(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_NoVerifyCmdLength(void)
@@ -1597,8 +1597,8 @@ void MM_LoadMemFromFileCmd_Test_NoVerifyCmdLength(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_NoReadFileHeaders(void)
@@ -1610,7 +1610,7 @@ void MM_LoadMemFromFileCmd_Test_NoReadFileHeaders(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CFE_FS_ReadHeader error received: RC = 0x%%08X Expected = %%u File = '%%s'");
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1653,8 +1653,8 @@ void MM_LoadMemFromFileCmd_Test_NoReadFileHeaders(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_NoVerifyLoadFileSize(void)
@@ -1666,7 +1666,7 @@ void MM_LoadMemFromFileCmd_Test_NoVerifyLoadFileSize(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Load file size error: Reported by OS = %%d Expected = %%u File = '%%s'");
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook1, 0);
@@ -1703,8 +1703,8 @@ void MM_LoadMemFromFileCmd_Test_NoVerifyLoadFileSize(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_lseekError(void)
@@ -1717,7 +1717,7 @@ void MM_LoadMemFromFileCmd_Test_lseekError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Load file CRC failure: Expected = 0x%%X Calculated = 0x%%X File = '%%s'");
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1760,8 +1760,8 @@ void MM_LoadMemFromFileCmd_Test_lseekError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_LoadParamsError(void)
@@ -1775,7 +1775,7 @@ void MM_LoadMemFromFileCmd_Test_LoadParamsError(void)
 
     UT_MM_CFE_OS_ReadHook1_MemType = 99;
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1815,8 +1815,8 @@ void MM_LoadMemFromFileCmd_Test_LoadParamsError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_SymNameError(void)
@@ -1830,7 +1830,7 @@ void MM_LoadMemFromFileCmd_Test_SymNameError(void)
 
     UT_MM_CFE_OS_ReadHook1_MemType = MM_MEM8;
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1871,8 +1871,8 @@ void MM_LoadMemFromFileCmd_Test_SymNameError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_LoadFileCRCError(void)
@@ -1887,7 +1887,7 @@ void MM_LoadMemFromFileCmd_Test_LoadFileCRCError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Load file CRC failure: Expected = 0x%%X Calculated = 0x%%X File = '%%s'");
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1931,8 +1931,8 @@ void MM_LoadMemFromFileCmd_Test_LoadFileCRCError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_ComputeCRCError(void)
@@ -1944,7 +1944,7 @@ void MM_LoadMemFromFileCmd_Test_ComputeCRCError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "MM_ComputeCRCFromFile error received: RC = 0x%%08X File = '%%s'");
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -1982,8 +1982,8 @@ void MM_LoadMemFromFileCmd_Test_ComputeCRCError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_CloseError(void)
@@ -1995,7 +1995,7 @@ void MM_LoadMemFromFileCmd_Test_CloseError(void)
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "OS_close error received: RC = 0x%%08X File = '%%s'");
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -2039,8 +2039,8 @@ void MM_LoadMemFromFileCmd_Test_CloseError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFileCmd_Test_OpenError(void)
@@ -2052,7 +2052,7 @@ void MM_LoadMemFromFileCmd_Test_OpenError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "OS_OpenCreate error received: RC = %%d File = '%%s'");
 
-    strncpy(UT_CmdBuf.LoadMemFromFileCmd.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.FileName) - 1);
+    strncpy(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName, "name", sizeof(UT_CmdBuf.LoadMemFromFileCmd.Payload.FileName) - 1);
 
     /* Causes call to MM_VerifyLoadFileSize to return true, in order to satisfy the immediately following condition
      * "Valid == true" */
@@ -2087,8 +2087,8 @@ void MM_LoadMemFromFileCmd_Test_OpenError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFile_Test_PreventCPUHogging(void)
@@ -2108,13 +2108,13 @@ void MM_LoadMemFromFile_Test_PreventCPUHogging(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_EEPROM, "MM_AppData.HkPacket.MemType == MM_EEPROM");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)(&Buffer[0]), "MM_AppData.HkPacket.Address == 0");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 2 * MM_MAX_LOAD_DATA_SEG,
-                  "MM_AppData.HkPacket.BytesProcessed == 2*MM_MAX_LOAD_DATA_SEG");
-    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName), FileName,
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_EEPROM, "MM_AppData.HkPacket.Payload.MemType == MM_EEPROM");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == (cpuaddr)(&Buffer[0]), "MM_AppData.HkPacket.Payload.Address == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 2 * MM_MAX_LOAD_DATA_SEG,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == 2*MM_MAX_LOAD_DATA_SEG");
+    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.Payload.FileName, sizeof(MM_AppData.HkPacket.Payload.FileName), FileName,
                           sizeof(FileName));
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -2122,8 +2122,8 @@ void MM_LoadMemFromFile_Test_PreventCPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFile_Test_ReadError(void)
@@ -2159,8 +2159,8 @@ void MM_LoadMemFromFile_Test_ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMemFromFile_Test_NotEepromMemType(void)
@@ -2180,13 +2180,13 @@ void MM_LoadMemFromFile_Test_NotEepromMemType(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM8, "MM_AppData.HkPacket.MemType == MM_MEM8");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)(&Buffer[0]), "MM_AppData.HkPacket.Address == 0");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 2 * MM_MAX_LOAD_DATA_SEG,
-                  "MM_AppData.HkPacket.BytesProcessed == 2*MM_MAX_LOAD_DATA_SEG");
-    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.FileName, sizeof(MM_AppData.HkPacket.FileName), FileName,
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM8, "MM_AppData.HkPacket.Payload.MemType == MM_MEM8");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == (cpuaddr)(&Buffer[0]), "MM_AppData.HkPacket.Payload.Address == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 2 * MM_MAX_LOAD_DATA_SEG,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == 2*MM_MAX_LOAD_DATA_SEG");
+    UtAssert_STRINGBUF_EQ(MM_AppData.HkPacket.Payload.FileName, sizeof(MM_AppData.HkPacket.Payload.FileName), FileName,
                           sizeof(FileName));
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -2194,8 +2194,8 @@ void MM_LoadMemFromFile_Test_NotEepromMemType(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_ReadFileHeaders_Test_ReadHeaderError(void)
@@ -2231,8 +2231,8 @@ void MM_ReadFileHeaders_Test_ReadHeaderError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_ReadFileHeaders_Test_ReadError(void)
@@ -2268,8 +2268,8 @@ void MM_ReadFileHeaders_Test_ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadFileSize_Test_StatError(void)
@@ -2303,8 +2303,8 @@ void MM_VerifyLoadFileSize_Test_StatError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadFileSize_Test_SizeError(void)
@@ -2340,8 +2340,8 @@ void MM_VerifyLoadFileSize_Test_SizeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMemCmd_Test_RAM(void)
@@ -2356,8 +2356,8 @@ void MM_FillMemCmd_Test_RAM(void)
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook3, 0);
 
-    UT_CmdBuf.FillMemCmd.MemType    = MM_RAM;
-    UT_CmdBuf.FillMemCmd.NumOfBytes = 1;
+    UT_CmdBuf.FillMemCmd.Payload.MemType    = MM_RAM;
+    UT_CmdBuf.FillMemCmd.Payload.NumOfBytes = 1;
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -2383,8 +2383,8 @@ void MM_FillMemCmd_Test_RAM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMemCmd_Test_EEPROM(void)
@@ -2399,8 +2399,8 @@ void MM_FillMemCmd_Test_EEPROM(void)
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook3, 0);
 
-    UT_CmdBuf.FillMemCmd.MemType    = MM_EEPROM;
-    UT_CmdBuf.FillMemCmd.NumOfBytes = 1;
+    UT_CmdBuf.FillMemCmd.Payload.MemType    = MM_EEPROM;
+    UT_CmdBuf.FillMemCmd.Payload.NumOfBytes = 1;
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -2426,8 +2426,8 @@ void MM_FillMemCmd_Test_EEPROM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMemCmd_Test_MEM32(void)
@@ -2439,10 +2439,10 @@ void MM_FillMemCmd_Test_MEM32(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Fill Memory Command: Filled %%d bytes at address: %%p with pattern: 0x%%08X");
 
-    UT_CmdBuf.FillMemCmd.MemType    = MM_MEM32;
-    UT_CmdBuf.FillMemCmd.NumOfBytes = 4;
+    UT_CmdBuf.FillMemCmd.Payload.MemType    = MM_MEM32;
+    UT_CmdBuf.FillMemCmd.Payload.NumOfBytes = 4;
 
-    /* Causes MM_AppData.HkPacket.LastAction == MM_FILL */
+    /* Causes MM_AppData.HkPacket.Payload.LastAction == MM_FILL */
     UT_SetHookFunction(UT_KEY(MM_FillMem32), UT_MM_LOAD_TEST_MM_FillMemHook1, 0);
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
@@ -2471,8 +2471,8 @@ void MM_FillMemCmd_Test_MEM32(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMemCmd_Test_MEM16(void)
@@ -2484,10 +2484,10 @@ void MM_FillMemCmd_Test_MEM16(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Fill Memory Command: Filled %%d bytes at address: %%p with pattern: 0x%%08X");
 
-    UT_CmdBuf.FillMemCmd.MemType    = MM_MEM16;
-    UT_CmdBuf.FillMemCmd.NumOfBytes = 2;
+    UT_CmdBuf.FillMemCmd.Payload.MemType    = MM_MEM16;
+    UT_CmdBuf.FillMemCmd.Payload.NumOfBytes = 2;
 
-    /* Causes MM_AppData.HkPacket.LastAction == MM_FILL */
+    /* Causes MM_AppData.HkPacket.Payload.LastAction == MM_FILL */
     UT_SetHookFunction(UT_KEY(MM_FillMem16), UT_MM_LOAD_TEST_MM_FillMemHook1, 0);
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
@@ -2516,8 +2516,8 @@ void MM_FillMemCmd_Test_MEM16(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMemCmd_Test_MEM8(void)
@@ -2529,10 +2529,10 @@ void MM_FillMemCmd_Test_MEM8(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Fill Memory Command: Filled %%d bytes at address: %%p with pattern: 0x%%08X");
 
-    UT_CmdBuf.FillMemCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.FillMemCmd.NumOfBytes = 1;
+    UT_CmdBuf.FillMemCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.FillMemCmd.Payload.NumOfBytes = 1;
 
-    /* Causes MM_AppData.HkPacket.LastAction == MM_FILL */
+    /* Causes MM_AppData.HkPacket.Payload.LastAction == MM_FILL */
     UT_SetHookFunction(UT_KEY(MM_FillMem8), UT_MM_LOAD_TEST_MM_FillMemHook1, 0);
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
@@ -2559,8 +2559,8 @@ void MM_FillMemCmd_Test_MEM8(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMemCmd_Test_SymNameError(void)
@@ -2572,10 +2572,10 @@ void MM_FillMemCmd_Test_SymNameError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Symbolic address can't be resolved: Name = '%%s'");
 
-    UT_CmdBuf.FillMemCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.FillMemCmd.NumOfBytes = 1;
+    UT_CmdBuf.FillMemCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.FillMemCmd.Payload.NumOfBytes = 1;
 
-    /* Causes MM_AppData.HkPacket.LastAction == MM_FILL */
+    /* Causes MM_AppData.HkPacket.Payload.LastAction == MM_FILL */
     UT_SetHookFunction(UT_KEY(MM_FillMem8), UT_MM_LOAD_TEST_MM_FillMemHook1, 0);
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
@@ -2598,15 +2598,15 @@ void MM_FillMemCmd_Test_SymNameError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMemCmd_Test_NoVerifyCmdLength(void)
 {
     bool Result;
 
-    /* Causes MM_AppData.HkPacket.LastAction == MM_FILL */
+    /* Causes MM_AppData.HkPacket.Payload.LastAction == MM_FILL */
     UT_SetHookFunction(UT_KEY(MM_FillMem8), UT_MM_LOAD_TEST_MM_FillMemHook1, 0);
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, false);
@@ -2622,16 +2622,16 @@ void MM_FillMemCmd_Test_NoVerifyCmdLength(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMemCmd_Test_NoLastActionFill(void)
 {
     bool Result;
 
-    UT_CmdBuf.FillMemCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.FillMemCmd.NumOfBytes = 1;
+    UT_CmdBuf.FillMemCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.FillMemCmd.Payload.NumOfBytes = 1;
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -2650,16 +2650,16 @@ void MM_FillMemCmd_Test_NoLastActionFill(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMemCmd_Test_NoVerifyLoadDump(void)
 {
     bool Result;
 
-    UT_CmdBuf.FillMemCmd.MemType    = MM_MEM8;
-    UT_CmdBuf.FillMemCmd.NumOfBytes = 1;
+    UT_CmdBuf.FillMemCmd.Payload.MemType    = MM_MEM8;
+    UT_CmdBuf.FillMemCmd.Payload.NumOfBytes = 1;
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -2678,8 +2678,8 @@ void MM_FillMemCmd_Test_NoVerifyLoadDump(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMemCmd_Test_BadType(void)
@@ -2689,8 +2689,8 @@ void MM_FillMemCmd_Test_BadType(void)
     /* Causes call to MM_ResolveSymAddr to return a known value for DestAddress */
     UT_SetHookFunction(UT_KEY(MM_ResolveSymAddr), UT_MM_LOAD_TEST_CFE_SymbolLookupHook3, 0);
 
-    UT_CmdBuf.FillMemCmd.MemType    = 99;
-    UT_CmdBuf.FillMemCmd.NumOfBytes = 1;
+    UT_CmdBuf.FillMemCmd.Payload.MemType    = 99;
+    UT_CmdBuf.FillMemCmd.Payload.NumOfBytes = 1;
 
     UT_SetDeferredRetcode(UT_KEY(MM_VerifyCmdLength), 1, true);
 
@@ -2705,8 +2705,8 @@ void MM_FillMemCmd_Test_BadType(void)
     UtAssert_True(Result == false, "Result == false");
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem_Test_Nominal(void)
@@ -2716,8 +2716,8 @@ void MM_FillMem_Test_Nominal(void)
 
     memset(&CmdPacket, 0, sizeof(CmdPacket));
 
-    CmdPacket.MemType    = MM_EEPROM;
-    CmdPacket.NumOfBytes = 2;
+    CmdPacket.Payload.MemType    = MM_EEPROM;
+    CmdPacket.Payload.NumOfBytes = 2;
     memset(Buffer, 1, (MM_MAX_FILL_DATA_SEG * 2));
 
     /* Execute the function being tested */
@@ -2726,20 +2726,20 @@ void MM_FillMem_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_FILL, "MM_AppData.HkPacket.LastAction == MM_FILL");
-    UtAssert_True(MM_AppData.HkPacket.MemType == CmdPacket.MemType, "MM_AppData.HkPacket.MemType == CmdPacket.MemType");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)Buffer, "MM_AppData.HkPacket.Address == (cpuaddr)Buffer");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern,
-                  "MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 2, "MM_AppData.HkPacket.BytesProcessed == 2");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_FILL, "MM_AppData.HkPacket.Payload.LastAction == MM_FILL");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == CmdPacket.Payload.MemType, "MM_AppData.HkPacket.Payload.MemType == CmdPacket.Payload.MemType");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == (cpuaddr)Buffer, "MM_AppData.HkPacket.Payload.Address == (cpuaddr)Buffer");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern,
+                  "MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 2, "MM_AppData.HkPacket.Payload.BytesProcessed == 2");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem_Test_MaxFillDataSegment(void)
@@ -2749,8 +2749,8 @@ void MM_FillMem_Test_MaxFillDataSegment(void)
 
     memset(&CmdPacket, 0, sizeof(CmdPacket));
 
-    CmdPacket.MemType    = MM_EEPROM;
-    CmdPacket.NumOfBytes = MM_MAX_FILL_DATA_SEG + 1;
+    CmdPacket.Payload.MemType    = MM_EEPROM;
+    CmdPacket.Payload.NumOfBytes = MM_MAX_FILL_DATA_SEG + 1;
 
     memset(Buffer, 1, (MM_MAX_FILL_DATA_SEG * 2));
     /* Execute the function being tested */
@@ -2759,21 +2759,21 @@ void MM_FillMem_Test_MaxFillDataSegment(void)
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
 
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_FILL, "MM_AppData.HkPacket.LastAction == MM_FILL");
-    UtAssert_True(MM_AppData.HkPacket.MemType == CmdPacket.MemType, "MM_AppData.HkPacket.MemType == CmdPacket.MemType");
-    UtAssert_True(MM_AppData.HkPacket.Address == (cpuaddr)Buffer, "MM_AppData.HkPacket.Address == (cpuaddr)Buffer");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern,
-                  "MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == MM_MAX_FILL_DATA_SEG + 1,
-                  "MM_AppData.HkPacket.BytesProcessed == MM_MAX_FILL_DATA_SEG + 1");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_FILL, "MM_AppData.HkPacket.Payload.LastAction == MM_FILL");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == CmdPacket.Payload.MemType, "MM_AppData.HkPacket.Payload.MemType == CmdPacket.Payload.MemType");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == (cpuaddr)Buffer, "MM_AppData.HkPacket.Payload.Address == (cpuaddr)Buffer");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern,
+                  "MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == MM_MAX_FILL_DATA_SEG + 1,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == MM_MAX_FILL_DATA_SEG + 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 /*

--- a/unit-test/mm_mem16_tests.c
+++ b/unit-test/mm_mem16_tests.c
@@ -70,14 +70,14 @@ void MM_LoadMem16FromFile_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM16, "MM_AppData.HkPacket.MemType == MM_MEM16");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM16, "MM_AppData.HkPacket.Payload.MemType == MM_MEM16");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -85,8 +85,8 @@ void MM_LoadMem16FromFile_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMem16FromFile_Test_CPUHogging(void)
@@ -106,14 +106,14 @@ void MM_LoadMem16FromFile_Test_CPUHogging(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM16, "MM_AppData.HkPacket.MemType == MM_MEM16");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM16, "MM_AppData.HkPacket.Payload.MemType == MM_MEM16");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -121,8 +121,8 @@ void MM_LoadMem16FromFile_Test_CPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMem16FromFile_Test_ReadError(void)
@@ -161,8 +161,8 @@ void MM_LoadMem16FromFile_Test_ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMem16FromFile_Test_WriteError(void)
@@ -207,8 +207,8 @@ void MM_LoadMem16FromFile_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem16ToFile_Test_Nominal(void)
@@ -226,15 +226,15 @@ void MM_DumpMem16ToFile_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM16, "MM_AppData.HkPacket.MemType == MM_MEM16");
-    UtAssert_True(MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset,
-                  "MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM16, "MM_AppData.HkPacket.Payload.MemType == MM_MEM16");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset,
+                  "MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -242,8 +242,8 @@ void MM_DumpMem16ToFile_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem16ToFile_Test_CPUHogging(void)
@@ -261,15 +261,15 @@ void MM_DumpMem16ToFile_Test_CPUHogging(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM16, "MM_AppData.HkPacket.MemType == MM_MEM16");
-    UtAssert_True(MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset,
-                  "MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM16, "MM_AppData.HkPacket.Payload.MemType == MM_MEM16");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset,
+                  "MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -277,8 +277,8 @@ void MM_DumpMem16ToFile_Test_CPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem16ToFile_Test_ReadError(void)
@@ -318,8 +318,8 @@ void MM_DumpMem16ToFile_Test_ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem16ToFile_Test_WriteError(void)
@@ -359,8 +359,8 @@ void MM_DumpMem16ToFile_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem16_Test_Nominal(void)
@@ -368,21 +368,21 @@ void MM_FillMem16_Test_Nominal(void)
     MM_FillMemCmd_t CmdPacket;
     uint32          DestAddress = 1;
     bool            Result;
-    CmdPacket.NumOfBytes  = 2;
-    CmdPacket.FillPattern = 3;
+    CmdPacket.Payload.NumOfBytes  = 2;
+    CmdPacket.Payload.FillPattern = 3;
 
     /* Execute the function being tested */
     Result = MM_FillMem16(DestAddress, &CmdPacket);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_FILL, "MM_AppData.HkPacket.LastAction == MM_FILL");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM16, "MM_AppData.HkPacket.MemType == MM_MEM16");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern,
-                  "MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_FILL, "MM_AppData.HkPacket.Payload.LastAction == MM_FILL");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM16, "MM_AppData.HkPacket.Payload.MemType == MM_MEM16");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern,
+                  "MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -390,8 +390,8 @@ void MM_FillMem16_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem16_Test_CPUHogging(void)
@@ -400,21 +400,21 @@ void MM_FillMem16_Test_CPUHogging(void)
     uint32          DestAddress = 1;
     bool            Result;
 
-    CmdPacket.NumOfBytes  = 2 * MM_MAX_LOAD_DATA_SEG;
-    CmdPacket.FillPattern = 3;
+    CmdPacket.Payload.NumOfBytes  = 2 * MM_MAX_LOAD_DATA_SEG;
+    CmdPacket.Payload.FillPattern = 3;
 
     /* Execute the function being tested */
     Result = MM_FillMem16(DestAddress, &CmdPacket);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_FILL, "MM_AppData.HkPacket.LastAction == MM_FILL");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM16, "MM_AppData.HkPacket.MemType == MM_MEM16");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern,
-                  "MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_FILL, "MM_AppData.HkPacket.Payload.LastAction == MM_FILL");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM16, "MM_AppData.HkPacket.Payload.MemType == MM_MEM16");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern,
+                  "MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -422,8 +422,8 @@ void MM_FillMem16_Test_CPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem16_Test_WriteError(void)
@@ -438,8 +438,8 @@ void MM_FillMem16_Test_WriteError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM16");
 
-    CmdPacket.NumOfBytes  = 2;
-    CmdPacket.FillPattern = 3;
+    CmdPacket.Payload.NumOfBytes  = 2;
+    CmdPacket.Payload.FillPattern = 3;
 
     /* Set to generate error message MM_PSP_WRITE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemWrite16), 1, -1);
@@ -462,16 +462,16 @@ void MM_FillMem16_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem16_Test_Align(void)
 {
     MM_FillMemCmd_t CmdPacket;
     uint32          DestAddress = 1;
-    CmdPacket.NumOfBytes        = 3;
-    CmdPacket.FillPattern       = 3;
+    CmdPacket.Payload.NumOfBytes        = 3;
+    CmdPacket.Payload.FillPattern       = 3;
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     bool  Result;
@@ -498,8 +498,8 @@ void MM_FillMem16_Test_Align(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 /*

--- a/unit-test/mm_mem32_tests.c
+++ b/unit-test/mm_mem32_tests.c
@@ -70,14 +70,14 @@ void MM_LoadMem32FromFile_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM32, "MM_AppData.HkPacket.MemType == MM_MEM32");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM32, "MM_AppData.HkPacket.Payload.MemType == MM_MEM32");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -85,8 +85,8 @@ void MM_LoadMem32FromFile_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMem32FromFile_Test_CPUHogging(void)
@@ -106,14 +106,14 @@ void MM_LoadMem32FromFile_Test_CPUHogging(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM32, "MM_AppData.HkPacket.MemType == MM_MEM32");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM32, "MM_AppData.HkPacket.Payload.MemType == MM_MEM32");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -121,8 +121,8 @@ void MM_LoadMem32FromFile_Test_CPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMem32FromFile_Test_ReadError(void)
@@ -161,8 +161,8 @@ void MM_LoadMem32FromFile_Test_ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMem32FromFile_Test_WriteError(void)
@@ -207,8 +207,8 @@ void MM_LoadMem32FromFile_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem32ToFile_Test_Nominal(void)
@@ -228,15 +228,15 @@ void MM_DumpMem32ToFile_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM32, "MM_AppData.HkPacket.MemType == MM_MEM32");
-    UtAssert_True(MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset,
-                  "MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM32, "MM_AppData.HkPacket.Payload.MemType == MM_MEM32");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset,
+                  "MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -244,8 +244,8 @@ void MM_DumpMem32ToFile_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem32ToFile_Test_CPUHogging(void)
@@ -263,15 +263,15 @@ void MM_DumpMem32ToFile_Test_CPUHogging(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM32, "MM_AppData.HkPacket.MemType == MM_MEM32");
-    UtAssert_True(MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset,
-                  "MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM32, "MM_AppData.HkPacket.Payload.MemType == MM_MEM32");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset,
+                  "MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -279,8 +279,8 @@ void MM_DumpMem32ToFile_Test_CPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem32ToFile_Test_ReadError(void)
@@ -320,8 +320,8 @@ void MM_DumpMem32ToFile_Test_ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem32ToFile_Test_WriteError(void)
@@ -361,8 +361,8 @@ void MM_DumpMem32ToFile_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem32_Test_Nominal(void)
@@ -371,21 +371,21 @@ void MM_FillMem32_Test_Nominal(void)
     uint32          DestAddress = 1;
     bool            Result;
 
-    CmdPacket.NumOfBytes  = 4;
-    CmdPacket.FillPattern = 3;
+    CmdPacket.Payload.NumOfBytes  = 4;
+    CmdPacket.Payload.FillPattern = 3;
 
     /* Execute the function being tested */
     Result = MM_FillMem32(DestAddress, &CmdPacket);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_FILL, "MM_AppData.HkPacket.LastAction == MM_FILL");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM32, "MM_AppData.HkPacket.MemType == MM_MEM32");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern,
-                  "MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_FILL, "MM_AppData.HkPacket.Payload.LastAction == MM_FILL");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM32, "MM_AppData.HkPacket.Payload.MemType == MM_MEM32");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern,
+                  "MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -393,8 +393,8 @@ void MM_FillMem32_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem32_Test_CPUHogging(void)
@@ -403,21 +403,21 @@ void MM_FillMem32_Test_CPUHogging(void)
     MM_FillMemCmd_t CmdPacket;
     uint32          DestAddress = 1;
 
-    CmdPacket.NumOfBytes  = 4 * MM_MAX_LOAD_DATA_SEG;
-    CmdPacket.FillPattern = 3;
+    CmdPacket.Payload.NumOfBytes  = 4 * MM_MAX_LOAD_DATA_SEG;
+    CmdPacket.Payload.FillPattern = 3;
 
     /* Execute the function being tested */
     Result = MM_FillMem32(DestAddress, &CmdPacket);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_FILL, "MM_AppData.HkPacket.LastAction == MM_FILL");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM32, "MM_AppData.HkPacket.MemType == MM_MEM32");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern,
-                  "MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_FILL, "MM_AppData.HkPacket.Payload.LastAction == MM_FILL");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM32, "MM_AppData.HkPacket.Payload.MemType == MM_MEM32");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern,
+                  "MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -425,8 +425,8 @@ void MM_FillMem32_Test_CPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem32_Test_WriteError(void)
@@ -441,8 +441,8 @@ void MM_FillMem32_Test_WriteError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM32");
 
-    CmdPacket.NumOfBytes  = 4;
-    CmdPacket.FillPattern = 3;
+    CmdPacket.Payload.NumOfBytes  = 4;
+    CmdPacket.Payload.FillPattern = 3;
 
     /* Set to generate error message MM_PSP_WRITE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemWrite32), 1, -1);
@@ -465,16 +465,16 @@ void MM_FillMem32_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem32_Test_Align(void)
 {
     MM_FillMemCmd_t CmdPacket;
     uint32          DestAddress = 1;
-    CmdPacket.NumOfBytes        = 5;
-    CmdPacket.FillPattern       = 3;
+    CmdPacket.Payload.NumOfBytes        = 5;
+    CmdPacket.Payload.FillPattern       = 3;
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     bool  Result;
@@ -501,8 +501,8 @@ void MM_FillMem32_Test_Align(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 /*

--- a/unit-test/mm_mem8_tests.c
+++ b/unit-test/mm_mem8_tests.c
@@ -70,14 +70,14 @@ void MM_LoadMem8FromFile_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM8, "MM_AppData.HkPacket.MemType == MM_MEM8");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM8, "MM_AppData.HkPacket.Payload.MemType == MM_MEM8");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -85,8 +85,8 @@ void MM_LoadMem8FromFile_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMem8FromFile_Test_CPUHogging(void)
@@ -106,14 +106,14 @@ void MM_LoadMem8FromFile_Test_CPUHogging(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_LOAD_FROM_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM8, "MM_AppData.HkPacket.MemType == MM_MEM8");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_LOAD_FROM_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM8, "MM_AppData.HkPacket.Payload.MemType == MM_MEM8");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -121,8 +121,8 @@ void MM_LoadMem8FromFile_Test_CPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMem8FromFile_Test_ReadError(void)
@@ -161,8 +161,8 @@ void MM_LoadMem8FromFile_Test_ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_LoadMem8FromFile_Test_WriteError(void)
@@ -207,8 +207,8 @@ void MM_LoadMem8FromFile_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem8ToFile_Test_Nominal(void)
@@ -228,15 +228,15 @@ void MM_DumpMem8ToFile_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM8, "MM_AppData.HkPacket.MemType == MM_MEM8");
-    UtAssert_True(MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset,
-                  "MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM8, "MM_AppData.HkPacket.Payload.MemType == MM_MEM8");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset,
+                  "MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -244,8 +244,8 @@ void MM_DumpMem8ToFile_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem8ToFile_Test_CPUHogging(void)
@@ -263,15 +263,15 @@ void MM_DumpMem8ToFile_Test_CPUHogging(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE,
-                  "MM_AppData.HkPacket.LastAction == MM_DUMP_TO_FILE");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM8, "MM_AppData.HkPacket.MemType == MM_MEM8");
-    UtAssert_True(MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset,
-                  "MM_AppData.HkPacket.Address == FileHeader.SymAddress.Offset");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == FileHeader.NumOfBytes");
-    UtAssert_True(strncmp(MM_AppData.HkPacket.FileName, "filename", OS_MAX_PATH_LEN) == 0,
-                  "MM_AppData.HkPacket.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_DUMP_TO_FILE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM8, "MM_AppData.HkPacket.Payload.MemType == MM_MEM8");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset,
+                  "MM_AppData.HkPacket.Payload.Address == FileHeader.SymAddress.Offset");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == FileHeader.NumOfBytes");
+    UtAssert_True(strncmp(MM_AppData.HkPacket.Payload.FileName, "filename", OS_MAX_PATH_LEN) == 0,
+                  "MM_AppData.HkPacket.Payload.FileName, 'filename', OS_MAX_PATH_LEN) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -279,8 +279,8 @@ void MM_DumpMem8ToFile_Test_CPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem8ToFile_Test_ReadError(void)
@@ -320,8 +320,8 @@ void MM_DumpMem8ToFile_Test_ReadError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_DumpMem8ToFile_Test_WriteError(void)
@@ -361,8 +361,8 @@ void MM_DumpMem8ToFile_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem8_Test_Nominal(void)
@@ -371,21 +371,21 @@ void MM_FillMem8_Test_Nominal(void)
     uint32          DestAddress = 1;
     bool            Result;
 
-    CmdPacket.NumOfBytes  = 2;
-    CmdPacket.FillPattern = 3;
+    CmdPacket.Payload.NumOfBytes  = 2;
+    CmdPacket.Payload.FillPattern = 3;
 
     /* Execute the function being tested */
     Result = MM_FillMem8(DestAddress, &CmdPacket);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_FILL, "MM_AppData.HkPacket.LastAction == MM_FILL");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM8, "MM_AppData.HkPacket.MemType == MM_MEM8");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern,
-                  "MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_FILL, "MM_AppData.HkPacket.Payload.LastAction == MM_FILL");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM8, "MM_AppData.HkPacket.Payload.MemType == MM_MEM8");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern,
+                  "MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -393,8 +393,8 @@ void MM_FillMem8_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem8_Test_CPUHogging(void)
@@ -402,21 +402,21 @@ void MM_FillMem8_Test_CPUHogging(void)
     MM_FillMemCmd_t CmdPacket;
     uint32          DestAddress = 1;
     bool            Result;
-    CmdPacket.NumOfBytes  = 2 * MM_MAX_LOAD_DATA_SEG;
-    CmdPacket.FillPattern = 3;
+    CmdPacket.Payload.NumOfBytes  = 2 * MM_MAX_LOAD_DATA_SEG;
+    CmdPacket.Payload.FillPattern = 3;
 
     /* Execute the function being tested */
     Result = MM_FillMem8(DestAddress, &CmdPacket);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_FILL, "MM_AppData.HkPacket.LastAction == MM_FILL");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_MEM8, "MM_AppData.HkPacket.MemType == MM_MEM8");
-    UtAssert_True(MM_AppData.HkPacket.Address == DestAddress, "MM_AppData.HkPacket.Address == DestAddress");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern,
-                  "MM_AppData.HkPacket.DataValue == CmdPacket.FillPattern");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes,
-                  "MM_AppData.HkPacket.BytesProcessed == CmdPacket.NumOfBytes");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_FILL, "MM_AppData.HkPacket.Payload.LastAction == MM_FILL");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_MEM8, "MM_AppData.HkPacket.Payload.MemType == MM_MEM8");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == DestAddress, "MM_AppData.HkPacket.Payload.Address == DestAddress");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern,
+                  "MM_AppData.HkPacket.Payload.DataValue == CmdPacket.Payload.FillPattern");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes,
+                  "MM_AppData.HkPacket.Payload.BytesProcessed == CmdPacket.Payload.NumOfBytes");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -424,8 +424,8 @@ void MM_FillMem8_Test_CPUHogging(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_FillMem8_Test_WriteError(void)
@@ -440,8 +440,8 @@ void MM_FillMem8_Test_WriteError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "PSP write memory error: RC=0x%%08X, Address=%%p, MemType=MEM8");
 
-    CmdPacket.NumOfBytes  = 2;
-    CmdPacket.FillPattern = 3;
+    CmdPacket.Payload.NumOfBytes  = 2;
+    CmdPacket.Payload.FillPattern = 3;
 
     /* Set to generate error message MM_PSP_WRITE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemWrite8), 1, -1);
@@ -465,8 +465,8 @@ void MM_FillMem8_Test_WriteError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 /*

--- a/unit-test/mm_utils_tests.c
+++ b/unit-test/mm_utils_tests.c
@@ -56,25 +56,25 @@ uint8 call_count_CFE_EVS_SendEvent;
 
 void MM_ResetHk_Test(void)
 {
-    MM_AppData.HkPacket.LastAction     = 1;
-    MM_AppData.HkPacket.MemType        = 2;
-    MM_AppData.HkPacket.Address        = 3;
-    MM_AppData.HkPacket.DataValue      = 4;
-    MM_AppData.HkPacket.BytesProcessed = 5;
-    MM_AppData.HkPacket.FileName[0]    = 6;
+    MM_AppData.HkPacket.Payload.LastAction     = 1;
+    MM_AppData.HkPacket.Payload.MemType        = 2;
+    MM_AppData.HkPacket.Payload.Address        = 3;
+    MM_AppData.HkPacket.Payload.DataValue      = 4;
+    MM_AppData.HkPacket.Payload.BytesProcessed = 5;
+    MM_AppData.HkPacket.Payload.FileName[0]    = 6;
 
     /* Execute the function being tested */
     MM_ResetHk();
 
     /* Verify results */
-    UtAssert_True(MM_AppData.HkPacket.LastAction == MM_NOACTION, "MM_AppData.HkPacket.LastAction == MM_NOACTION");
-    UtAssert_True(MM_AppData.HkPacket.MemType == MM_NOMEMTYPE, "MM_AppData.HkPacket.MemType == MM_NOMEMTYPE");
-    UtAssert_True(MM_AppData.HkPacket.Address == MM_CLEAR_ADDR, "MM_AppData.HkPacket.Address == MM_CLEAR_ADDR");
-    UtAssert_True(MM_AppData.HkPacket.DataValue == MM_CLEAR_PATTERN,
-                  "MM_AppData.HkPacket.DataValue == MM_CLEAR_PATTERN");
-    UtAssert_True(MM_AppData.HkPacket.BytesProcessed == 0, "MM_AppData.BytesProcessed == 0");
-    UtAssert_True(MM_AppData.HkPacket.FileName[0] == MM_CLEAR_FNAME,
-                  "MM_AppData.HkPacket.FileName[0] == MM_CLEAR_FNAME");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_NOACTION, "MM_AppData.HkPacket.Payload.LastAction == MM_NOACTION");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_NOMEMTYPE, "MM_AppData.HkPacket.Payload.MemType == MM_NOMEMTYPE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == MM_CLEAR_ADDR, "MM_AppData.HkPacket.Payload.Address == MM_CLEAR_ADDR");
+    UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == MM_CLEAR_PATTERN,
+                  "MM_AppData.HkPacket.Payload.DataValue == MM_CLEAR_PATTERN");
+    UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 0, "MM_AppData.BytesProcessed == 0");
+    UtAssert_True(MM_AppData.HkPacket.Payload.FileName[0] == MM_CLEAR_FNAME,
+                  "MM_AppData.HkPacket.Payload.FileName[0] == MM_CLEAR_FNAME");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -82,8 +82,8 @@ void MM_ResetHk_Test(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyCmdLength_Test_Nominal(void)
@@ -113,8 +113,8 @@ void MM_VerifyCmdLength_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyCmdLength_Test_HKRequestLengthError(void)
@@ -153,8 +153,8 @@ void MM_VerifyCmdLength_Test_HKRequestLengthError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyCmdLength_Test_LengthError(void)
@@ -193,8 +193,8 @@ void MM_VerifyCmdLength_Test_LengthError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_SegmentBreak_Test_Nominal(void)
@@ -210,8 +210,8 @@ void MM_SegmentBreak_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_ByteWidthRAM(void)
@@ -233,8 +233,8 @@ void MM_VerifyPeekPokeParams_Test_ByteWidthRAM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_WordWidthMEM16(void)
@@ -256,8 +256,8 @@ void MM_VerifyPeekPokeParams_Test_WordWidthMEM16(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_DWordWidthMEM32(void)
@@ -279,8 +279,8 @@ void MM_VerifyPeekPokeParams_Test_DWordWidthMEM32(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_WordWidthAlignmentError(void)
@@ -314,8 +314,8 @@ void MM_VerifyPeekPokeParams_Test_WordWidthAlignmentError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_DWordWidthAlignmentError(void)
@@ -349,8 +349,8 @@ void MM_VerifyPeekPokeParams_Test_DWordWidthAlignmentError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_InvalidDataSize(void)
@@ -384,8 +384,8 @@ void MM_VerifyPeekPokeParams_Test_InvalidDataSize(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_EEPROM(void)
@@ -407,8 +407,8 @@ void MM_VerifyPeekPokeParams_Test_EEPROM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_MEM8(void)
@@ -430,8 +430,8 @@ void MM_VerifyPeekPokeParams_Test_MEM8(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_RAMValidateRangeError(void)
@@ -468,8 +468,8 @@ void MM_VerifyPeekPokeParams_Test_RAMValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_EEPROMValidateRangeError(void)
@@ -506,8 +506,8 @@ void MM_VerifyPeekPokeParams_Test_EEPROMValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_MEM32ValidateRangeError(void)
@@ -544,8 +544,8 @@ void MM_VerifyPeekPokeParams_Test_MEM32ValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_MEM16ValidateRangeError(void)
@@ -582,8 +582,8 @@ void MM_VerifyPeekPokeParams_Test_MEM16ValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_MEM8ValidateRangeError(void)
@@ -620,8 +620,8 @@ void MM_VerifyPeekPokeParams_Test_MEM8ValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_MEM32InvalidDataSize(void)
@@ -654,8 +654,8 @@ void MM_VerifyPeekPokeParams_Test_MEM32InvalidDataSize(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_MEM16InvalidDataSize(void)
@@ -688,8 +688,8 @@ void MM_VerifyPeekPokeParams_Test_MEM16InvalidDataSize(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_MEM8InvalidDataSize(void)
@@ -722,8 +722,8 @@ void MM_VerifyPeekPokeParams_Test_MEM8InvalidDataSize(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyPeekPokeParams_Test_InvalidMemType(void)
@@ -756,8 +756,8 @@ void MM_VerifyPeekPokeParams_Test_InvalidMemType(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 /*************************************/
@@ -798,8 +798,8 @@ void MM_VerifyLoadDumpParams_Test_LoadRAMValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooSmall(void)
@@ -832,8 +832,8 @@ void MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooLarge(void)
@@ -866,8 +866,8 @@ void MM_VerifyLoadDumpParams_Test_LoadRAMDataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadEEPROMValidateRangeError(void)
@@ -903,8 +903,8 @@ void MM_VerifyLoadDumpParams_Test_LoadEEPROMValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooSmall(void)
@@ -937,8 +937,8 @@ void MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooLarge(void)
@@ -971,8 +971,8 @@ void MM_VerifyLoadDumpParams_Test_LoadEEPROMDataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM32ValidateRangeError(void)
@@ -1008,8 +1008,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32ValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooSmall(void)
@@ -1042,8 +1042,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooLarge(void)
@@ -1076,8 +1076,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32DataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM32AlignmentError(void)
@@ -1110,8 +1110,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM32AlignmentError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM16ValidateRangeError(void)
@@ -1147,8 +1147,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16ValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooSmall(void)
@@ -1181,8 +1181,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooLarge(void)
@@ -1215,8 +1215,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16DataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM16AlignmentError(void)
@@ -1249,8 +1249,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM16AlignmentError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM8ValidateRangeError(void)
@@ -1286,8 +1286,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM8ValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooSmall(void)
@@ -1320,8 +1320,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooLarge(void)
@@ -1354,8 +1354,8 @@ void MM_VerifyLoadDumpParams_Test_LoadMEM8DataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadInvalidMemTypeError(void)
@@ -1387,8 +1387,8 @@ void MM_VerifyLoadDumpParams_Test_LoadInvalidMemTypeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_LoadInvalidVerifyTypeError(void)
@@ -1409,8 +1409,8 @@ void MM_VerifyLoadDumpParams_Test_LoadInvalidVerifyTypeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 /* Dumping */
@@ -1433,8 +1433,8 @@ void MM_VerifyLoadDumpParams_Test_DumpRAM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEEPROM(void)
@@ -1456,8 +1456,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM32(void)
@@ -1481,8 +1481,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM16(void)
@@ -1506,8 +1506,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM8(void)
@@ -1531,8 +1531,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpRAMRangeError(void)
@@ -1569,8 +1569,8 @@ void MM_VerifyLoadDumpParams_Test_DumpRAMRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooSmall(void)
@@ -1604,8 +1604,8 @@ void MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooLarge(void)
@@ -1639,8 +1639,8 @@ void MM_VerifyLoadDumpParams_Test_DumpRAMInvalidSizeTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEEPROMRangeError(void)
@@ -1677,8 +1677,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROMRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooSmall(void)
@@ -1712,8 +1712,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooLarge(void)
@@ -1747,8 +1747,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEEPROMInvalidSizeTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM32RangeError(void)
@@ -1785,8 +1785,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32RangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooSmall(void)
@@ -1820,8 +1820,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooLarge(void)
@@ -1855,8 +1855,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32InvalidSizeTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM32AlignmentError(void)
@@ -1890,8 +1890,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM32AlignmentError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM16RangeError(void)
@@ -1928,8 +1928,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16RangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooSmall(void)
@@ -1963,8 +1963,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooLarge(void)
@@ -1998,8 +1998,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16InvalidSizeTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM16AlignmentError(void)
@@ -2033,8 +2033,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM16AlignmentError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM8RangeError(void)
@@ -2071,8 +2071,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8RangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooSmall(void)
@@ -2106,8 +2106,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooLarge(void)
@@ -2141,8 +2141,8 @@ void MM_VerifyLoadDumpParams_Test_DumpMEM8InvalidSizeTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpInvalidMemoryType(void)
@@ -2178,8 +2178,8 @@ void MM_VerifyLoadDumpParams_Test_DumpInvalidMemoryType(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 /* Dump in event */
@@ -2203,8 +2203,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventRAM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventEEPROM(void)
@@ -2226,8 +2226,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventEEPROM(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM32(void)
@@ -2249,8 +2249,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM16(void)
@@ -2272,8 +2272,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM8(void)
@@ -2295,8 +2295,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM8(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooSmall(void)
@@ -2330,8 +2330,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooLarge(void)
@@ -2365,8 +2365,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventInvalidDataSizeTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventRAMRangeError(void)
@@ -2403,8 +2403,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventRAMRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventEEPROMRangeError(void)
@@ -2441,8 +2441,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventEEPROMRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM32RangeError(void)
@@ -2479,8 +2479,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32RangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM32AlignmentError(void)
@@ -2514,8 +2514,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM32AlignmentError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM16RangeError(void)
@@ -2552,8 +2552,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16RangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM16AlignmentError(void)
@@ -2587,8 +2587,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM16AlignmentError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventMEM8RangeError(void)
@@ -2625,8 +2625,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventMEM8RangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_DumpEventInvalidMemType(void)
@@ -2662,8 +2662,8 @@ void MM_VerifyLoadDumpParams_Test_DumpEventInvalidMemType(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* no command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 /* Fill */
@@ -2701,8 +2701,8 @@ void MM_VerifyLoadDumpParams_Test_FillRAMValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooSmall(void)
@@ -2735,8 +2735,8 @@ void MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooLarge(void)
@@ -2769,8 +2769,8 @@ void MM_VerifyLoadDumpParams_Test_FillRAMDataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillEEPROMValidateRangeError(void)
@@ -2806,8 +2806,8 @@ void MM_VerifyLoadDumpParams_Test_FillEEPROMValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooSmall(void)
@@ -2840,8 +2840,8 @@ void MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooLarge(void)
@@ -2874,8 +2874,8 @@ void MM_VerifyLoadDumpParams_Test_FillEEPROMDataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM32ValidateRangeError(void)
@@ -2911,8 +2911,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32ValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooSmall(void)
@@ -2945,8 +2945,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooLarge(void)
@@ -2979,8 +2979,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32DataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM32AlignmentError(void)
@@ -3013,8 +3013,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM32AlignmentError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM16ValidateRangeError(void)
@@ -3050,8 +3050,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16ValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooSmall(void)
@@ -3084,8 +3084,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooLarge(void)
@@ -3118,8 +3118,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16DataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM16AlignmentError(void)
@@ -3152,8 +3152,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM16AlignmentError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM8ValidateRangeError(void)
@@ -3189,8 +3189,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM8ValidateRangeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooSmall(void)
@@ -3223,8 +3223,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooLarge(void)
@@ -3257,8 +3257,8 @@ void MM_VerifyLoadDumpParams_Test_FillMEM8DataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_FillInvalidMemTypeError(void)
@@ -3290,8 +3290,8 @@ void MM_VerifyLoadDumpParams_Test_FillInvalidMemTypeError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 /* WID */
@@ -3312,8 +3312,8 @@ void MM_VerifyLoadDumpParams_Test_WIDNominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_WIDMemValidateError(void)
@@ -3349,8 +3349,8 @@ void MM_VerifyLoadDumpParams_Test_WIDMemValidateError(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooSmall(void)
@@ -3383,8 +3383,8 @@ void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooSmall(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooLarge(void)
@@ -3417,8 +3417,8 @@ void MM_VerifyLoadDumpParams_Test_WIDDataSizeErrorTooLarge(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* No command-handling function should be updating the cmd or err counter itself */
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.CmdCounter, 0);
-    UtAssert_INT32_EQ(MM_AppData.HkPacket.ErrCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.CmdCounter, 0);
+    UtAssert_INT32_EQ(MM_AppData.HkPacket.Payload.ErrCounter, 0);
 }
 
 void MM_Verify32Aligned_Test(void)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/MM/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #80, adds Payload substructure to all command and telemetry messages

**Testing performed**
unit testing

**Expected behavior changes**
 no impact to behavior

**System(s) tested on**
 - OS: Ubuntu 18.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Haven Carlson - NASA