### PR TITLE
Fix #15, Use `CFE_MSG_PTR` instead of `&(x).Msg`

### DIFF
--- a/fsw/inc/mm_msg.h
+++ b/fsw/inc/mm_msg.h
@@ -183,7 +183,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 } MM_NoArgsCmd_t;
 
 /**
@@ -193,7 +193,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
     MM_PeekCmd_Payload_t    Payload;
 } MM_PeekCmd_t;
 
@@ -204,7 +204,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
     MM_PokeCmd_Payload_t    Payload;
 } MM_PokeCmd_t;
 
@@ -215,7 +215,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t    CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t    CommandHeader; /**< \brief Command header */
     MM_LoadMemWIDCmd_Payload_t Payload;
 } MM_LoadMemWIDCmd_t;
 
@@ -226,7 +226,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
     MM_DumpInEventCmd_Payload_t Payload;
 } MM_DumpInEventCmd_t;
 
@@ -237,7 +237,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t         CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t         CommandHeader; /**< \brief Command header */
     MM_LoadMemFromFileCmd_Payload_t Payload;
 } MM_LoadMemFromFileCmd_t;
 
@@ -248,7 +248,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t       CommandHeader; /**< \brief Command header */
     MM_DumpMemToFileCmd_Payload_t Payload;
 } MM_DumpMemToFileCmd_t;
 
@@ -259,7 +259,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
     MM_FillMemCmd_Payload_t Payload;
 } MM_FillMemCmd_t;
 
@@ -270,7 +270,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t   CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t   CommandHeader; /**< \brief Command header */
     MM_LookupSymCmd_Payload_t Payload;
 } MM_LookupSymCmd_t;
 
@@ -281,7 +281,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
     MM_SymTblToFileCmd_Payload_t Payload;
 } MM_SymTblToFileCmd_t;
 
@@ -292,7 +292,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t        CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t        CommandHeader; /**< \brief Command header */
     MM_EepromWriteEnaCmd_Payload_t Payload;
 } MM_EepromWriteEnaCmd_t;
 
@@ -303,7 +303,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t        CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t        CommandHeader; /**< \brief Command header */
     MM_EepromWriteDisCmd_Payload_t Payload;
 } MM_EepromWriteDisCmd_t;
 
@@ -335,7 +335,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry header */
     MM_HkPacket_Payload_t     Payload;
 } MM_HkPacket_t;
 

--- a/fsw/src/mm_app.c
+++ b/fsw/src/mm_app.c
@@ -162,7 +162,8 @@ CFE_Status_t MM_AppInit(void)
     /*
     ** Initialize the local housekeeping telemetry packet (clear user data area)
     */
-    CFE_MSG_Init(&MM_AppData.HkPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(MM_HK_TLM_MID), sizeof(MM_HkPacket_t));
+    CFE_MSG_Init(CFE_MSG_PTR(MM_AppData.HkPacket.TelemetryHeader), CFE_SB_ValueToMsgId(MM_HK_TLM_MID),
+                 sizeof(MM_HkPacket_t));
 
     /*
     ** Create Software Bus message pipe
@@ -390,8 +391,8 @@ void MM_HousekeepingCmd(const CFE_SB_Buffer_t *BufPtr)
     /*
     ** Send housekeeping telemetry packet
     */
-    CFE_SB_TimeStampMsg(&MM_AppData.HkPacket.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&MM_AppData.HkPacket.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(MM_AppData.HkPacket.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(MM_AppData.HkPacket.TelemetryHeader), true);
 
     /*
     ** This command does not affect the command execution counter

--- a/unit-test/mm_utils_tests.c
+++ b/unit-test/mm_utils_tests.c
@@ -67,9 +67,12 @@ void MM_ResetHk_Test(void)
     MM_ResetHk();
 
     /* Verify results */
-    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_NOACTION, "MM_AppData.HkPacket.Payload.LastAction == MM_NOACTION");
-    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_NOMEMTYPE, "MM_AppData.HkPacket.Payload.MemType == MM_NOMEMTYPE");
-    UtAssert_True(MM_AppData.HkPacket.Payload.Address == MM_CLEAR_ADDR, "MM_AppData.HkPacket.Payload.Address == MM_CLEAR_ADDR");
+    UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_NOACTION,
+                  "MM_AppData.HkPacket.Payload.LastAction == MM_NOACTION");
+    UtAssert_True(MM_AppData.HkPacket.Payload.MemType == MM_NOMEMTYPE,
+                  "MM_AppData.HkPacket.Payload.MemType == MM_NOMEMTYPE");
+    UtAssert_True(MM_AppData.HkPacket.Payload.Address == MM_CLEAR_ADDR,
+                  "MM_AppData.HkPacket.Payload.Address == MM_CLEAR_ADDR");
     UtAssert_True(MM_AppData.HkPacket.Payload.DataValue == MM_CLEAR_PATTERN,
                   "MM_AppData.HkPacket.Payload.DataValue == MM_CLEAR_PATTERN");
     UtAssert_True(MM_AppData.HkPacket.Payload.BytesProcessed == 0, "MM_AppData.BytesProcessed == 0");
@@ -102,7 +105,7 @@ void MM_VerifyCmdLength_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = MM_VerifyCmdLength(&UT_CmdBuf.PeekCmd.CmdHeader.Msg, ExpectedLength);
+    Result = MM_VerifyCmdLength(CFE_MSG_PTR(UT_CmdBuf.PeekCmd.CommandHeader), ExpectedLength);
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
@@ -135,7 +138,7 @@ void MM_VerifyCmdLength_Test_HKRequestLengthError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = MM_VerifyCmdLength(&UT_CmdBuf.PeekCmd.CmdHeader.Msg, ExpectedLength);
+    Result = MM_VerifyCmdLength(CFE_MSG_PTR(UT_CmdBuf.PeekCmd.CommandHeader), ExpectedLength);
 
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");
@@ -175,7 +178,7 @@ void MM_VerifyCmdLength_Test_LengthError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = MM_VerifyCmdLength(&UT_CmdBuf.PeekCmd.CmdHeader.Msg, ExpectedLength);
+    Result = MM_VerifyCmdLength(CFE_MSG_PTR(UT_CmdBuf.PeekCmd.CommandHeader), ExpectedLength);
 
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #15
  - Local unwrappings replaced with the abstracted `CFE_MSG_PTR` macro
  - Minor related naming convention updates:
    - `CmdHeader` renamed to `CommandHeader`
    - `TlmHeader` renamed to `TelemetryHeader`

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt