### PR TITLE
Fix #10, Rename `MM_ResetHk` to `MM_ResetHkData` + memset global data at initialization

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ A clear and concise description of what the contribution is.
 **Testing performed**
 Steps taken to test the contribution:
 1. Build steps '...'
-1. Execution steps '...'
+2. Execution steps '...'
 
 **Expected behavior changes**
 A clear and concise description of how this contribution will change behavior and level of impact.

--- a/fsw/inc/mm_msg.h
+++ b/fsw/inc/mm_msg.h
@@ -277,7 +277,7 @@ typedef struct
 /**
  *  \brief Save Symbol Table To File Command
  *
- *  For command details see #MM_SYMTBL_TO_FILE_CC
+ *  For command details see #MM_SYM_TBL_TO_FILE_CC
  */
 typedef struct
 {

--- a/fsw/inc/mm_msgdefs.h
+++ b/fsw/inc/mm_msgdefs.h
@@ -601,7 +601,7 @@
  *  \par Criticality
  *       None
  *
- *  \sa #MM_SYMTBL_TO_FILE_CC
+ *  \sa #MM_SYM_TBL_TO_FILE_CC
  */
 #define MM_LOOKUP_SYM_CC 9
 
@@ -644,7 +644,7 @@
  *
  *  \sa #MM_LOOKUP_SYM_CC
  */
-#define MM_SYMTBL_TO_FILE_CC 10
+#define MM_SYM_TBL_TO_FILE_CC 10
 
 /**
  * \brief EEPROM Write Enable

--- a/fsw/inc/mm_platform_cfg.h
+++ b/fsw/inc/mm_platform_cfg.h
@@ -91,7 +91,7 @@
 #define MM_MAX_LOAD_FILE_DATA_EEPROM (128 * 1024)
 
 /**
- * \brief Maximum number of bytes for an uninterruptable load
+ * \brief Maximum number of bytes for an uninterruptible load
  *
  *  \par Description:
  *       Maximum number of bytes that can be loaded with the

--- a/fsw/src/mm_app.c
+++ b/fsw/src/mm_app.c
@@ -137,16 +137,13 @@ CFE_Status_t MM_AppInit(void)
     ** If this changes add it here as shown in the qq_app.c template
     */
 
+    /* Zero out the global data structure */
+    memset(&MM_AppData, 0, sizeof(MM_AppData));
+
     /*
     ** Setup the RunStatus variable
     */
     MM_AppData.RunStatus = CFE_ES_RunStatus_APP_RUN;
-
-    /*
-    ** Initialize application command execution counters
-    */
-    MM_AppData.HkPacket.Payload.CmdCounter = 0;
-    MM_AppData.HkPacket.Payload.ErrCounter = 0;
 
     /*
     ** Register for event services
@@ -210,7 +207,7 @@ CFE_Status_t MM_AppInit(void)
     /*
     ** Initialize MM housekeeping information
     */
-    MM_ResetHk();
+    MM_ResetHkData();
 
     /*
     ** Application startup event message
@@ -251,7 +248,7 @@ void MM_AppPipe(const CFE_SB_Buffer_t *BufPtr)
         ** MM ground commands
         */
         case MM_CMD_MID:
-            MM_ResetHk(); /* Clear all "Last Action" data */
+            MM_ResetHkData(); /* Clear all "Last Action" data */
 
             CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
             switch (CommandCode)
@@ -326,7 +323,7 @@ void MM_AppPipe(const CFE_SB_Buffer_t *BufPtr)
                     }
                     break;
 
-                case MM_SYMTBL_TO_FILE_CC:
+                case MM_SYM_TBL_TO_FILE_CC:
                     if (MM_VerifyCmdLength(&BufPtr->Msg, sizeof(MM_SymTblToFileCmd_t)))
                     {
                         CmdResult = MM_SymTblToFileCmd(BufPtr);

--- a/fsw/src/mm_app.h
+++ b/fsw/src/mm_app.h
@@ -205,7 +205,7 @@ bool MM_LookupSymbolCmd(const CFE_SB_Buffer_t *msg);
  *
  *  \param[in] msg Pointer to Software Bus buffer
  *
- *  \sa #MM_SYMTBL_TO_FILE_CC
+ *  \sa #MM_SYM_TBL_TO_FILE_CC
  */
 bool MM_SymTblToFileCmd(const CFE_SB_Buffer_t *msg);
 

--- a/fsw/src/mm_utils.c
+++ b/fsw/src/mm_utils.c
@@ -49,7 +49,7 @@ extern MM_AppData_t MM_AppData;
 /* Reset the local housekeeping variables to default parameters    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void MM_ResetHk(void)
+void MM_ResetHkData(void)
 {
     MM_AppData.HkPacket.Payload.LastAction     = MM_NOACTION;
     MM_AppData.HkPacket.Payload.MemType        = MM_NOMEMTYPE;
@@ -541,7 +541,7 @@ bool MM_ResolveSymAddr(MM_SymAddr_t *SymAddr, cpuaddr *ResolvedAddr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Compute the CRC of data in a file                               */
-/* Operates from the current location of the file poiner to EOF    */
+/* Operates from the current location of the file pointer to EOF   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 MM_ComputeCRCFromFile(osal_id_t FileHandle, uint32 *CrcPtr, uint32 TypeCRC)

--- a/fsw/src/mm_utils.h
+++ b/fsw/src/mm_utils.h
@@ -45,7 +45,7 @@
  *       This function does not zero the command execution counter
  *       or the command error counter
  */
-void MM_ResetHk(void);
+void MM_ResetHkData(void);
 
 /**
  * \brief Segment break

--- a/fsw/src/mm_verify.h
+++ b/fsw/src/mm_verify.h
@@ -58,7 +58,7 @@
 #endif
 
 /*
- *  Maximum number of bytes for an uninterruptable load
+ *  Maximum number of bytes for an uninterruptible load
  */
 #if MM_MAX_UNINTERRUPTIBLE_DATA < 1
 #error MM_MAX_UNINTERRUPTIBLE_DATA cannot be less than 1

--- a/unit-test/mm_app_tests.c
+++ b/unit-test/mm_app_tests.c
@@ -913,7 +913,7 @@ void MM_AppPipe_Test_LookupSymbolFail(void)
 void MM_AppPipe_Test_SymTblToFileSuccess(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = MM_SYMTBL_TO_FILE_CC;
+    CFE_MSG_FcnCode_t FcnCode   = MM_SYM_TBL_TO_FILE_CC;
     size_t            MsgSize   = sizeof(UT_CmdBuf.SymTblToFileCmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -945,7 +945,7 @@ void MM_AppPipe_Test_SymTblToFileSuccess(void)
 void MM_AppPipe_Test_SymTblToFileFail(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = MM_SYMTBL_TO_FILE_CC;
+    CFE_MSG_FcnCode_t FcnCode   = MM_SYM_TBL_TO_FILE_CC;
     size_t            MsgSize   = sizeof(UT_CmdBuf.SymTblToFileCmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -1321,7 +1321,7 @@ void MM_LookupSymbolCmd_Test_SymbolLookupError(void)
 void MM_SymTblToFileCmd_Test_Nominal(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = MM_SYMTBL_TO_FILE_CC;
+    CFE_MSG_FcnCode_t FcnCode   = MM_SYM_TBL_TO_FILE_CC;
     size_t            MsgSize   = sizeof(UT_CmdBuf.SymTblToFileCmd);
     int32             strCmpResult;
     char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -1367,7 +1367,7 @@ void MM_SymTblToFileCmd_Test_Nominal(void)
 void MM_SymTblToFileCmd_Test_SymbolFilenameNull(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = MM_SYMTBL_TO_FILE_CC;
+    CFE_MSG_FcnCode_t FcnCode   = MM_SYM_TBL_TO_FILE_CC;
     size_t            MsgSize   = sizeof(UT_CmdBuf.SymTblToFileCmd);
     int32             strCmpResult;
     char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -1407,7 +1407,7 @@ void MM_SymTblToFileCmd_Test_SymbolFilenameNull(void)
 void MM_SymTblToFileCmd_Test_SymbolTableDumpError(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(MM_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = MM_SYMTBL_TO_FILE_CC;
+    CFE_MSG_FcnCode_t FcnCode   = MM_SYM_TBL_TO_FILE_CC;
     size_t            MsgSize   = sizeof(UT_CmdBuf.SymTblToFileCmd);
     int32             strCmpResult;
     char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -1602,7 +1602,7 @@ void MM_EepromWriteDisCmd_Test_Error(void)
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(MM_VerifyCmdLength), true);
 
-    /* Set to generate error message MM_EEPROM_WRITE_DISA_ERR_EID */
+    /* Set to generate error message MM_EEPROM_WRITE_DIS_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_EepromWriteDisable), 1, -1);
 
     /* Execute the function being tested */

--- a/unit-test/mm_dump_tests.c
+++ b/unit-test/mm_dump_tests.c
@@ -1669,7 +1669,7 @@ void MM_DumpInEventCmd_Test_Nominal(void)
     char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     bool              Result;
 
-    /* The event string is dynamically generated with string contatentation
+    /* The event string is dynamically generated with string concatenation
        and is reported in context_CFE_EVS_SendEvent as a single string.
        The event string cannot be matched to a preformatted value. */
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s");

--- a/unit-test/mm_utils_tests.c
+++ b/unit-test/mm_utils_tests.c
@@ -54,7 +54,7 @@ uint8 call_count_CFE_EVS_SendEvent;
  * Function Definitions
  */
 
-void MM_ResetHk_Test(void)
+void MM_ResetHkData_Test(void)
 {
     MM_AppData.HkPacket.Payload.LastAction     = 1;
     MM_AppData.HkPacket.Payload.MemType        = 2;
@@ -64,7 +64,7 @@ void MM_ResetHk_Test(void)
     MM_AppData.HkPacket.Payload.FileName[0]    = 6;
 
     /* Execute the function being tested */
-    MM_ResetHk();
+    MM_ResetHkData();
 
     /* Verify results */
     UtAssert_True(MM_AppData.HkPacket.Payload.LastAction == MM_NOACTION, "MM_AppData.HkPacket.Payload.LastAction == MM_NOACTION");
@@ -3571,7 +3571,7 @@ void MM_ComputeCRCFromFile_Test(void)
  */
 void UtTest_Setup(void)
 {
-    UtTest_Add(MM_ResetHk_Test, MM_Test_Setup, MM_Test_TearDown, "MM_ResetHk_Test");
+    UtTest_Add(MM_ResetHkData_Test, MM_Test_Setup, MM_Test_TearDown, "MM_ResetHkData_Test");
     UtTest_Add(MM_VerifyCmdLength_Test_Nominal, MM_Test_Setup, MM_Test_TearDown, "MM_VerifyCmdLength_Test_Nominal");
     UtTest_Add(MM_VerifyCmdLength_Test_HKRequestLengthError, MM_Test_Setup, MM_Test_TearDown,
                "MM_VerifyCmdLength_Test_HKRequestLengthError");

--- a/unit-test/stubs/mm_utils_stubs.c
+++ b/unit-test/stubs/mm_utils_stubs.c
@@ -38,9 +38,9 @@
 #include "utassert.h"
 #include "utstubs.h"
 
-void MM_ResetHk(void)
+void MM_ResetHkData(void)
 {
-    UT_DEFAULT_IMPL(MM_ResetHk);
+    UT_DEFAULT_IMPL(MM_ResetHkData);
 }
 
 void MM_SegmentBreak(void)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #10
  - `MM_ResetHk` renamed to `MM_ResetHkData` to improve clarity
  - Minor issues tagging along with this PR:
    - Zero out the entire global data structure during initialization (rather than just the command/error counters)
    - Separate the 2 separate words `SYM` and `TBL` in `MM_SYMTBL_TO_FILE_CC` as per the naming conventions
    - Various typo fixes

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt