### PR TITLE
Fix #12, remove redundant Perf ID log in MM_SegmentBreak

### DIFF
--- a/fsw/inc/mm_perfids.h
+++ b/fsw/inc/mm_perfids.h
@@ -30,10 +30,9 @@
  */
 
 #define MM_APPMAIN_PERF_ID         30 /**< \brief Application main performance ID */
-#define MM_SEGBREAK_PERF_ID        31 /**< \brief Memory processing segment break performance ID */
-#define MM_EEPROM_POKE_PERF_ID     32 /**< \brief EEPROM poke performance ID */
-#define MM_EEPROM_FILELOAD_PERF_ID 33 /**< \brief EEPROM file load performance ID */
-#define MM_EEPROM_FILL_PERF_ID     34 /**< \brief EEPROM fill performance ID */
+#define MM_EEPROM_POKE_PERF_ID     31 /**< \brief EEPROM poke performance ID */
+#define MM_EEPROM_FILELOAD_PERF_ID 32 /**< \brief EEPROM file load performance ID */
+#define MM_EEPROM_FILL_PERF_ID     33 /**< \brief EEPROM fill performance ID */
 
 /**\}*/
 

--- a/fsw/src/mm_utils.c
+++ b/fsw/src/mm_utils.c
@@ -27,7 +27,6 @@
 *************************************************************************/
 #include "mm_app.h"
 #include "mm_utils.h"
-#include "mm_perfids.h"
 #include "mm_msgids.h"
 #include "mm_events.h"
 #include "mm_dump.h"
@@ -67,19 +66,9 @@ void MM_ResetHk(void)
 void MM_SegmentBreak(void)
 {
     /*
-    ** Performance Log entry stamp
-    */
-    CFE_ES_PerfLogEntry(MM_SEGBREAK_PERF_ID);
-
-    /*
     ** Give something else the chance to run
     */
     OS_TaskDelay(MM_PROCESSOR_CYCLE);
-
-    /*
-    ** Performance Log exit stamp
-    */
-    CFE_ES_PerfLogExit(MM_SEGBREAK_PERF_ID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #12 

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Will not record this PerfLog anymore which wasn't actually testing anything to do with MM app performance anyway.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt