### PR TITLE
Fix #100, Check CFE_SB_NO_MESSAGE return code

### DIFF
--- a/fsw/src/mm_app.c
+++ b/fsw/src/mm_app.c
@@ -91,7 +91,7 @@ void MM_AppMain(void) {
     if ((Status == CFE_SUCCESS) && (BufPtr != NULL)) {
       /* Process Software Bus message */
       MM_TaskPipe(BufPtr);
-    } else if (Status == CFE_SB_TIME_OUT) {
+    } else if (Status == CFE_SB_TIME_OUT || Status == CFE_SB_NO_MESSAGE) {
       /* No action, but also no error */
     } else {
       /*

--- a/unit-test/mm_app_tests.c
+++ b/unit-test/mm_app_tests.c
@@ -47,6 +47,14 @@
 /* Function Definitions */
 /* ==================== */
 
+int32 MM_APP_TEST_CFE_ES_ExitAppHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                     const UT_StubContext_t *Context)
+{
+    MM_AppData.HkTlm.Payload.CmdCounter++;
+
+    return 0;
+}
+
 void MM_AppMain_Test_Nominal(void) {
   CFE_SB_Buffer_t Buf;
   CFE_SB_Buffer_t *BufPtr = &Buf;
@@ -119,6 +127,32 @@ void MM_AppMain_Test_SBTimeout(void) {
   /* Verify results */
   /* Generates 1 event message we don't care about in this test */
   UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+}
+
+void MM_AppMain_Test_SBNoMessage(void)
+{
+    size_t         forced_Size  = 1;
+    CFE_SB_MsgId_t forced_MsgID = MM_UT_MID_1;
+
+    /* Set to exit loop after first run */
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_RunLoop), 1, true);
+
+    /* Set to generate error message CFE_SB_NO_MESSAGE */
+    UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SB_NO_MESSAGE);
+
+    /* Set to prevent segmentation fault */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
+
+    /* Used to verify completion of MM_AppMain by incrementing MM_AppData.HkPacket.CmdCounter. */
+    UT_SetHookFunction(UT_KEY(CFE_ES_ExitApp), MM_APP_TEST_CFE_ES_ExitAppHook, NULL);
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(MM_AppMain());
+
+    /* Verify results */
+    /* Generates 1 event message we don't care about in this test */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void MM_AppInit_Test_Nominal(void) {
@@ -271,6 +305,7 @@ void UtTest_Setup(void) {
   ADD_TEST(MM_AppMain_Test_AppInitError);
   ADD_TEST(MM_AppMain_Test_SBError);
   ADD_TEST(MM_AppMain_Test_SBTimeout);
+  ADD_TEST(MM_AppMain_Test_SBNoMessage);
   ADD_TEST(MM_AppInit_Test_Nominal);
   ADD_TEST(MM_AppInit_Test_EVSRegisterError);
   ADD_TEST(MM_AppInit_Test_SBCreatePipeError);


### PR DESCRIPTION
Fix #100, check cfe_sb_no_message return code from CFE_SB_ReceiveBuffer

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/MM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]
Update to check for no message. 

**Testing performed**
Steps taken to test the contribution:
1. make SIMULATION=native install
2. Run cfs

1. make SIMULATION=native ENABLE_UNIT_TESTS=true install
2. make test
3.  make lcov

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLA's apply to software contributions.
Anh Van, GSFC
