### PR TITLE
Fix #114, Initialize PSP_Status in mm_dump.c

### DIFF
--- a/fsw/src/mm_dump.c
+++ b/fsw/src/mm_dump.c
@@ -265,7 +265,7 @@ int32 MM_FillDumpInEventBuffer(cpuaddr SrcAddress, const MM_DumpInEventCmd_t *Cm
     uint32 i;
 #endif
     /* cppcheck-suppress unusedVariable */
-    int32 PSP_Status;
+    int32 PSP_Status = CFE_PSP_ERROR;
 
     /* Initialize buffer */
     memset(DumpBuffer, 0, MM_INTERNAL_MAX_DUMP_INEVENT_BYTES);
@@ -360,7 +360,6 @@ int32 MM_FillDumpInEventBuffer(cpuaddr SrcAddress, const MM_DumpInEventCmd_t *Cm
             /* This branch will never be executed. CmdPtr->Payload.MemType will always
              * be valid value for this switch statement it is verified via
              * MM_VerifyFileLoadDumpParams */
-            PSP_Status = CFE_PSP_ERROR;
             break;
 
     } /* end CmdPtr->Payload.MemType switch */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #114

**Testing performed**
GitHub Actions and CodeSonar

**Expected behavior changes**
Resolve CodeSonar warnings on uninitialized variables

**System(s) tested on**
GitHub Actions and CodeSonar. CodeSonar results will be posted on the internal ticket.

**Additional context**


**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.